### PR TITLE
feat(core/desktop/tui): multi-session chat runtime

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,6 @@
         "@modelcontextprotocol/sdk": "^1.12.1",
         "glob": "^11.0.0",
         "gpt-tokenizer": "^3.4.0",
-        "lodash-es": "^4.17.23",
         "nanoid": "^5.1.2",
         "openai": "^4.82.0",
         "proper-lockfile": "^4.1.2",

--- a/docs/superpowers/specs/2026-05-26-multi-session-chat-runtime-design.md
+++ b/docs/superpowers/specs/2026-05-26-multi-session-chat-runtime-design.md
@@ -1,0 +1,442 @@
+# Multi-Session Chat Runtime — Design
+
+Date: 2026-05-26
+Status: Implemented (commits 55448c6..a3f2388)
+Scope: `packages/core/src/protocol/`, `packages/core/src/engine/`, `packages/core/src/tool-system/{permission,builtin/plan}`, `packages/desktop/src/{preload,renderer}`, `packages/tui/src/cli/commands/`.
+
+## 1. Background and problem statement
+
+### 1.1 Observed symptom
+
+On the Electron client, when a chat session is still running and the user opens a second chat tab and sends a message, the second message vanishes silently. The UI shows nothing — no error, no echo of the user message, just a spinner that never resolves. The first session itself also eventually appears to stall (no `turn_complete`, UI keeps spinning), even though the underlying worker subprocess exits cleanly.
+
+### 1.2 Root causes (three independent bugs, in three layers)
+
+1. **Server layer — single-flag rejection.**
+   `packages/core/src/protocol/server.ts:115` rejects every concurrent `agent/run` with `ErrorCodes.AlreadyRunning (-32003)` using a single boolean `this.running`. The `sessionId` parameter that the client sends is not consulted at all. This is the only reason "two different chat tabs cannot run at the same time", and the rejection is silent on the renderer.
+
+2. **Renderer layer — single-ref event routing.**
+   `packages/desktop/src/renderer/App.tsx:425-460` stores the "currently running bucket" in a single `runningBucketRef.current`. All inbound stream events are routed to whatever bucket that ref points to. The first `turn_complete` (or `error`) clears the ref. After that, `if (!target) return;` on line 427 silently discards every subsequent event. In the captured trace, the bridge forwarded 8,107 stream events over six minutes while the renderer recorded only ~100 — a 98.8% drop rate.
+
+3. **Subagent layer — events outlive parent turn.**
+   Subagent events (`agentId: ...`) share the same `streamToClient` callback as the parent run. When a parent run emits `turn_complete` while a subagent is still working, the subagent's later events have no place to land. This compounds bug 2 by producing events that the renderer cannot attribute to any bucket.
+
+### 1.3 What is NOT a root cause (clarified during exploration)
+
+- **`sessionId` is not the issue.** UI, preload bridge, and the JSON-RPC wire format all already carry `sessionId` per request. Only `server.ts` ignores it.
+- **`permissionMode` / `planMode` module singletons** (`tool-system/permission.ts:472`, `tool-system/builtin/plan.ts:47`) are not actively biting today, but they will the moment a second concurrent session uses a different mode. They must be removed as part of this work.
+- **`RunManager` is not the answer for chat.** The existing `packages/core/src/run/RunManager.ts` already implements multi-run, queueing, approval, and attach, but it is targeted at *managed runs* (persisted to `~/.code-shell/runs/<runId>/`, queued, recoverable). Chat runs are ephemeral; writing every chat turn to disk via `RunStore` is the wrong cost model. See §2.3 for the precedent in Claude Code (`query.ts` vs `QueryEngine.ts`).
+
+### 1.4 Industry baseline
+
+Verified during exploration:
+
+| Project | Process model | Concurrency model |
+|---|---|---|
+| Codex (`codex-rs/app-server`) | single long-lived process | multiple threads in parallel; **single-turn exclusivity per thread**; bounded queues + backpressure (`-32001`) |
+| Claude Code | two engines: `query.ts` (REPL), `QueryEngine.ts` (SDK/background) | multiple conversations concurrent; per-conversation turn sequential |
+| opencode (sst) | client–server | multiple SQLite-backed sessions; event bus via SSE |
+| Claude Agent SDK | in-process | `asyncio.gather()` of independent `query()` calls |
+
+The consensus is unambiguous: **multi-session concurrent + per-session turn sequential**, with `chat` and `managed/background` paths kept as separate subsystems.
+
+## 2. Goals and non-goals
+
+### 2.1 Goals
+
+- Allow N concurrent chat sessions in one worker process (N = number of UI tabs). Different sessions run truly in parallel.
+- Within a single chat session, turns are FIFO-serialized. A second `agent/run` for the same session queues behind the first.
+- Restore at-most-once delivery and correct attribution of every stream event, including subagent events.
+- Remove the module-level singletons for permission/plan mode; route those through per-session state.
+- Keep `RunManager` and the `run/*` protocol untouched. Chat path and managed path remain two parallel subsystems.
+- TUI behavior unchanged: TUI uses exactly one chat session, which is the degenerate case of the multi-session runtime.
+
+### 2.2 Non-goals
+
+- No persistence for chat runs. Conversation history continues to live in `SessionManager` as it does today; we do not write `RunSnapshot` per turn.
+- No new "managed run" features. `RunManager` is out of scope.
+- No multi-worker / multi-process renderer model. Still one Electron worker, one TUI in-process server — the unit of multiplexing is the *chat session*, not the OS process.
+- No turn-level parallelism within a session.
+- No protocol backward-compat shim. The user has explicitly opted out of compatibility — see §4 for the new wire format.
+
+### 2.3 Why a new subsystem (not RunManager)
+
+This mirrors Claude Code's split between `query.ts` (interactive, fast, no required persistence) and `QueryEngine.ts` (SDK, structured, persistent). Forcing chat through `RunManager` would either (a) write every chat turn to disk, paying I/O for ephemeral state, or (b) bolt an `ephemeral: true` mode onto `RunManager` that branches every method — strictly more code than a focused `ChatSessionManager`. The existing spec `2026-05-24-codex-grade-run-control-recovery-design.md` describes `run/*` as a *separate* protocol surface for managed runs, which is consistent with this split.
+
+## 3. Architecture
+
+### 3.1 Component map
+
+```
+                            ┌──────────────────────────────────┐
+                            │ AgentServer (protocol/server.ts) │
+                            │  • dispatches agent/* methods    │
+                            │  • dispatches run/*  methods     │
+                            └────────┬───────────────┬─────────┘
+                                     │               │
+                                     ▼               ▼
+                ┌────────────────────────────┐   ┌─────────────┐
+                │ ChatSessionManager  (NEW)  │   │ RunManager  │
+                │  Map<sessionId, ChatSess>  │   │ (untouched) │
+                └─────────┬──────────────────┘   └─────────────┘
+                          │
+                          ▼ one per chat tab
+                ┌──────────────────────────────────┐
+                │ ChatSession                      │
+                │  • engine: Engine                │
+                │  • turnQueue: FIFO (active≤1)    │
+                │  • controller: AbortController   │
+                │  • pendingApprovals: Map<id,...> │
+                │  • permissionMode, planMode      │
+                └──────────────────────────────────┘
+```
+
+`Engine` is now instantiated per `ChatSession` (one Engine per chat tab). The `EngineRuntime` shared-resources object (model pool, tool registry, settings, MCP pool) is hoisted out of `Engine` so multiple `Engine` instances can share read-only resources cheaply.
+
+### 3.2 Lifecycle
+
+- A `ChatSession` is created lazily the first time a `sessionId` is seen on `agent/run`.
+- Sessions are kept warm in memory; they are evicted only when (a) the client explicitly closes (`agent/closeSession`) or (b) idle longer than `chatSessionIdleTtlMs` (default 30 min, matching Codex's thread eviction).
+- A worker restart wipes all in-memory sessions. Chat sessions are NOT recoverable across worker restarts — that is what `RunManager` / `run/recover` is for. After a worker restart the renderer starts fresh (any pending UI turns become orphaned and should be marked stale).
+- Cancelling a turn (`agent/cancel`) aborts only that session's `AbortController`; other sessions are unaffected.
+- Worker shutdown drains all sessions, then exits.
+
+### 3.3 Subagent attribution
+
+Today, subagent events flow through the *parent* `streamToClient`. Going forward:
+
+- The wrapping `agent/streamEvent` notification always carries `sessionId` (required) — this is the only thing the renderer needs for routing.
+- Each `StreamEvent` payload optionally carries `parentTurnId` (the turn that spawned this subagent) and `agentId` (the subagent identifier). Both are absent on plain top-level events.
+
+`turn_complete` for the parent does NOT remove the per-session route — the route is keyed on `sessionId`, not on the turn lifecycle. The route only goes away on session close / idle eviction. Subagent events that arrive after the parent `turn_complete` are still routed correctly because they belong to the same `sessionId`.
+
+## 4. Protocol
+
+No backward compatibility. New wire format:
+
+### 4.1 Client → server
+
+```jsonc
+// Begin a turn in a chat session.
+{ "method": "agent/run", "params": {
+    "sessionId": "...",          // required; client-minted ULID
+    "task": "...",
+    "cwd": "...",
+    "permissionMode": "...",     // optional; defaults to session's existing mode
+    "planMode": false            // optional
+}}
+
+// Cancel a turn (must specify which session).
+{ "method": "agent/cancel", "params": { "sessionId": "..." } }
+
+// Approve / deny a tool call.
+{ "method": "agent/approve", "params": {
+    "sessionId": "...",
+    "requestId": "...",
+    "decision": { "approved": true } | { "approved": false, "reason": "..." }
+}}
+
+// Close a session (frees Engine + history).
+{ "method": "agent/closeSession", "params": { "sessionId": "..." } }
+
+// Per-session or global configure.
+{ "method": "agent/configure", "params": {
+    "sessionId": "..." | null,   // null = worker-global
+    "planMode": ..., "permissionMode": ..., "model": ..., ...
+}}
+```
+
+### 4.2 Server → client (notifications)
+
+Every notification carries `sessionId`:
+
+```jsonc
+{ "method": "agent/streamEvent", "params": {
+    "sessionId": "...",
+    "event": { ...StreamEvent }   // event keeps existing shape (text_delta, tool_use_start, ...)
+}}
+
+{ "method": "agent/approvalRequest", "params": {
+    "sessionId": "...",
+    "requestId": "...",
+    "request": { ...ToolApprovalRequest }
+}}
+
+{ "method": "agent/sessionStatus", "params": {
+    "sessionId": "...",
+    "status": "running" | "idle" | "queued" | "closed",
+    "queueDepth": 0
+}}
+```
+
+### 4.3 Server → client (responses)
+
+`agent/run`'s response carries the engine-side conversation/session id (today this is generated inside Engine on first turn). It must echo the client's `sessionId` back:
+
+```jsonc
+{ "id": ..., "result": {
+    "sessionId": "...",       // echoes request
+    "text": "...",
+    "reason": "completed" | "cancelled" | "max_turns" | "error",
+    "turnCount": N,
+    "usage": { ... }
+}}
+```
+
+### 4.4 Errors
+
+| Code | Meaning |
+|---|---|
+| `-32602` `InvalidParams` | missing `sessionId`, malformed |
+| `-32001` `Overloaded` | global ceiling exceeded (see §6.3); replaces old `-32003` `AlreadyRunning` |
+| `-32004` `SessionClosed` | targeting a session that has been closed/evicted |
+
+`-32003 AlreadyRunning` is removed.
+
+### 4.5 Stream events: subagent fields
+
+`StreamEvent` (defined in `packages/core/src/types.ts`) gains:
+
+```ts
+parentTurnId?: string;   // present on every event; identifies the originating turn
+agentId?: string;        // already exists; identifies subagent (if any)
+```
+
+`sessionId` does NOT need to be on the StreamEvent itself — it lives on the wrapping `agent/streamEvent` notification.
+
+## 5. Data flow
+
+### 5.1 Happy path: tab A sends, then tab B sends
+
+```
+T0  renderer A → run(sessionId=A, task=...)
+T0  AgentServer:
+      sessionA = ChatSessionManager.getOrCreate(A)
+      sessionA.queue.enqueue(turnA)
+      turnA starts immediately (queue was empty)
+      streams events with sessionId=A
+T1  renderer B → run(sessionId=B, task=...)
+T1  AgentServer:
+      sessionB = ChatSessionManager.getOrCreate(B)
+      sessionB.queue.enqueue(turnB)
+      turnB starts immediately (independent queue)
+      streams events with sessionId=B
+T2  events from both interleave on the JSON-RPC pipe
+T2  renderer routes by sessionId from envelope, no global ref
+```
+
+### 5.2 Same-session second send (queued)
+
+```
+T0  run(sessionId=A, task=task1) → enqueued, starts
+T1  run(sessionId=A, task=task2) → enqueued, queue depth = 1
+    AgentServer immediately notifies:
+      agent/sessionStatus { sessionId=A, status="queued", queueDepth=1 }
+T2  task1 finishes → turn_complete with sessionId=A
+T2  agent/sessionStatus { sessionId=A, status="running" }, task2 starts
+```
+
+The UI is now able to show "queued (1 ahead)" instead of silently dropping the message.
+
+### 5.3 Cancellation
+
+```
+renderer A → cancel(sessionId=A)
+AgentServer:
+  sessionA.controller.abort()
+  drain sessionA.queue → emit cancelled events for queued turns
+  sessionB untouched
+```
+
+### 5.4 Renderer routing
+
+Renderer maintains:
+
+```ts
+const sessionIdToBucket = new Map<string, BucketId>();
+const busyBySession    = new Map<string, boolean>();
+```
+
+The preload bridge (`packages/desktop/src/preload/index.ts`) parses each incoming `agent/streamEvent` notification and invokes the listener with the envelope `{ sessionId, event }`. On every callback:
+
+```ts
+window.codeshell.onStreamEvent(({ sessionId, event }) => {
+  const bucket = sessionIdToBucket.get(sessionId);
+  if (!bucket) return;                  // session is closed/unknown — discard intentionally
+  dispatch({ type: "stream", bucket, event });
+  if (event.type === "turn_complete" || event.type === "error") {
+    busyBySession.set(sessionId, false);
+  }
+});
+```
+
+`runningBucketRef` is deleted. `setBusyForKey` is replaced by `busyBySession` updates keyed on `sessionId`, so each tab tracks its own busy state independently.
+
+## 6. Components in detail
+
+### 6.1 `EngineRuntime` (new file: `packages/core/src/engine/runtime.ts`)
+
+Holds the *read-only / shared* resources that all `Engine` instances in a worker can share:
+
+```ts
+class EngineRuntime {
+  readonly modelPool: ModelPool;
+  readonly toolRegistry: ToolRegistry;
+  readonly settings: SettingsStore;
+  readonly mcpPool: McpConnectionPool;
+  readonly costTracker: CostTracker;
+}
+```
+
+Constructed once per worker. Engine takes it via constructor.
+
+### 6.2 `Engine` (modified: `packages/core/src/engine/engine.ts`)
+
+- Constructor now takes `runtime: EngineRuntime` plus per-instance config.
+- `permissionMode`, `planMode`, `askUser` become instance fields (not module singletons).
+- `engine.run()` signature unchanged on the outside; inside it uses `this.runtime.*` for shared resources.
+- Subagent spawn (`engine.ts:473` `new Engine(...)`) reuses the same runtime: `new Engine({ runtime: this.runtime, ... })`.
+
+### 6.3 `ChatSessionManager` (new file: `packages/core/src/protocol/chat-session-manager.ts`)
+
+```ts
+class ChatSessionManager {
+  constructor(opts: {
+    runtime: EngineRuntime;
+    maxSessions: number;          // default 16 — global ceiling for backpressure
+    idleTtlMs: number;            // default 30 * 60 * 1000
+  });
+
+  /**
+   * `engineConfig` is the per-session slice from the agent/run params
+   * (permissionMode, planMode, model overrides, etc.) — i.e. the subset of
+   * EngineConfig that the client controls on a per-request basis. Shared
+   * resources (modelPool, toolRegistry, settings, mcpPool) come from `runtime`.
+   */
+  getOrCreate(sessionId: string, engineConfig: EngineConfigSlice): ChatSession;
+  get(sessionId: string): ChatSession | undefined;
+  close(sessionId: string): void;
+  closeAll(): void;
+  sessionCount(): number;
+}
+
+class ChatSession {
+  readonly id: string;
+  readonly engine: Engine;
+  enqueueTurn(task: string, opts: TurnOpts): Promise<RunResult>;
+  cancel(): void;
+  isBusy(): boolean;
+  queueDepth(): number;
+  pendingApprovals: Map<string, (decision: ApprovalDecision) => void>;
+}
+```
+
+Global ceiling: when `sessionCount() >= maxSessions` and `getOrCreate` is called with a *new* sessionId, return `-32001 Overloaded`. Existing sessions are never rejected.
+
+### 6.4 `AgentServer` (modified: `packages/core/src/protocol/server.ts`)
+
+- Constructor takes `chatManager: ChatSessionManager` (required, for `agent/*`) and `runManager?: RunManager` (optional, for `run/*`). If `runManager` is absent, any `run/*` request returns `-32601 MethodNotFound`. The `engine` field is removed — Engines are created lazily by `ChatSessionManager`.
+- `handleRun` looks up the session, enqueues the turn, awaits.
+- `handleApprove`, `handleCancel` route by `sessionId`.
+- `handleConfigure` supports per-session and worker-global config.
+- `agent/closeSession` is added.
+- `this.running` and `this.abortController` are deleted.
+- Per-session `pendingApprovals` lives on `ChatSession`; the server-level map is removed.
+
+### 6.5 `cli/agent-server-stdio.ts` (modified)
+
+```ts
+const runtime = new EngineRuntime(config);
+const chatManager = new ChatSessionManager({ runtime, maxSessions, idleTtlMs });
+const runManager  = new RunManager({ ... });
+const server = new AgentServer({ chatManager, runManager, transport });
+```
+
+### 6.6 TUI `repl.ts` / `run.ts` (modified)
+
+Same change: build a `EngineRuntime`, build a `ChatSessionManager`, wire into `AgentServer`. TUI uses a single sessionId (`"tui-main"`), so it is degenerate multi-session. No TUI UI code changes.
+
+### 6.7 Preload (`packages/desktop/src/preload/index.ts`)
+
+`run`, `cancel`, `approve` all take/forward `sessionId`. Stream-listener API changes to deliver `{ sessionId, event }` envelopes instead of raw `event` — listeners now key on sessionId for routing.
+
+### 6.8 Renderer (`packages/desktop/src/renderer/App.tsx`)
+
+Single ref `runningBucketRef` is removed. Replace with `sessionIdToBucket: Map<sessionId, bucket>` and `busyBySession: Map<sessionId, boolean>`. Stream handler routes by `env.sessionId`. When a tab is created, its sessionId is registered; when closed, it's unregistered and `agent/closeSession` is sent.
+
+### 6.9 Permission / plan modules
+
+- `packages/core/src/tool-system/permission.ts`: delete module-level `runtimeBypass` let and `setRuntimeBypass`/`isRuntimeBypass` exports. All call sites read from `ToolContext.permissionMode` (sourced from the owning Engine).
+- `packages/core/src/tool-system/builtin/plan.ts`: delete module-level `inPlanMode` let and helpers. Plan tool reads from `ToolContext.planMode`.
+- `ToolContext` already exists (`tool-system/context.ts`); it gains `permissionMode` and `planMode` fields populated by Engine at tool dispatch time.
+
+## 7. Error handling and backpressure
+
+- **Global ceiling**: `ChatSessionManager.maxSessions` (default 16). Beyond this, *new* `sessionId`s get `-32001 Overloaded`. Existing sessions are unaffected. Renderer surfaces this as a toast.
+- **Per-session queue**: unbounded by default but `agent/sessionStatus` notifies `queueDepth` each enqueue so the UI can warn.
+- **Worker crash**: same as today — bridge respawns, all in-memory sessions are lost. (Recovery is out of scope; if needed it goes through the existing `RunManager`/`run/recover` path.)
+- **Cancel race**: if `agent/cancel` arrives while a turn is mid-stream, abort triggers, but events already in the JSON-RPC pipe may still reach the client. Client treats post-cancel events as informational and stops them at the bucket boundary by checking session status.
+- **Session-closed event**: a stream event for a closed sessionId is dropped at the renderer (intentional — `sessionIdToBucket.get` returns undefined). No error to user.
+
+## 8. Testing strategy
+
+### 8.1 Core unit tests
+
+- `tests/chat-session-manager.test.ts`
+  - `getOrCreate` is idempotent.
+  - Two concurrent sessions don't interfere (different abort signals, different histories).
+  - Same-session turns serialize (turn 2 waits for turn 1).
+  - `maxSessions` ceiling returns `-32001` for the (N+1)-th new sessionId, but existing sessions still work.
+  - Idle eviction at `idleTtlMs`.
+  - `close()` aborts in-flight turn, drains queue, fires cancelled events.
+
+- `tests/engine-runtime.test.ts`
+  - Two `Engine` instances over one `EngineRuntime` don't share mutable state.
+  - `permissionMode` is per-instance.
+  - `planMode` is per-instance.
+
+- Update `tests/protocol/agent-server.test.ts` (and `in-process-client-drift.test.ts`) to the new wire shape:
+  - `agent/run` without `sessionId` → `-32602`.
+  - `agent/run` for two different `sessionId`s in parallel → both complete; events tagged correctly.
+  - `agent/run` for same `sessionId` twice → second one queues; `agent/sessionStatus` fires.
+  - `agent/cancel` only affects the targeted session.
+
+### 8.2 Integration (in-process transport)
+
+- `tests/multi-session-integration.test.ts`: start `AgentServer` with in-process transport, fire two `run` calls on different `sessionId`s, assert event streams are well-formed, independent, and the renderer-style routing reconstructs each session's transcript losslessly.
+
+### 8.3 TUI regression
+
+- `tests/tui-repl.test.ts` (or extend existing TUI tests): single-session behavior is unchanged; the new wire format with `sessionId="tui-main"` produces identical Ink output.
+
+### 8.4 Desktop manual smoke
+
+Documented in the plan, not a unit test:
+1. Open Electron app, open two project tabs.
+2. In tab A, send a long task ("review repo X").
+3. While A is running, in tab B send another task.
+4. Verify: both run concurrently, both tabs show their own stream, neither stalls, `turn_complete` arrives for each.
+5. In tab A, send a second message before the first completes.
+6. Verify: UI shows "queued"; second runs after first finishes.
+7. Cancel tab A mid-turn.
+8. Verify: A stops, B unaffected.
+
+## 9. Migration / rollout
+
+Single landing PR per phase (see implementation plan for breakdown). No flags, no shims — the user has explicitly waived backward compatibility. Old `-32003` callers will see `-32602` (missing sessionId) or `-32001` (overload); both are clearer than the old single-flag rejection.
+
+## 10. Out of scope (deferred)
+
+- Multi-worker process model (one OS process per session) — current design keeps one worker per Electron app and one in-process server per TUI.
+- Cross-session history sharing or fork — each session is a sealed conversation.
+- Persistent chat (recovering chat sessions after worker crash) — chat is ephemeral by design; managed recovery stays in `RunManager` / `run/recover`.
+- Renderer-side queue visualization beyond a simple "queued" badge.
+
+## 11. Open questions
+
+None at write time. All previously open decisions were resolved during brainstorming:
+
+- two paths (chat + managed run): keep both ✅
+- same-session second send: queue, not parallel ✅
+- backward compatibility: not required ✅
+- runId vs sessionId on the wire: `sessionId` only (`runId` was a phantom; the actual existing field is `sessionId`) ✅

--- a/packages/core/src/cli/agent-server-stdio.ts
+++ b/packages/core/src/cli/agent-server-stdio.ts
@@ -1,0 +1,127 @@
+/**
+ * agent-server-stdio — Electron worker entry point.
+ *
+ * Bootstraps EngineRuntime + ChatSessionManager and exposes AgentServer
+ * over a newline-delimited JSON stdio transport so Electron's main process
+ * (or any other parent that spawns this file as a child process) can drive
+ * multi-session agent runs through the standard protocol.
+ *
+ * Bootstrap approach (bootstrap-then-extract / approach a):
+ *   1. Construct a single "seed" Engine without a runtime.  Engine's
+ *      constructor calls populateModelPoolFromSettings() which reads
+ *      settings.json, registers model entries and provider catalog, and
+ *      resolves the active model — exactly the initialization work we need.
+ *   2. Extract the fully-populated modelPool and toolRegistry from the seed
+ *      engine, plus construct SettingsManager, MCPManager, CostTracker.
+ *   3. Wrap those shared resources in an EngineRuntime.
+ *   4. Pass the runtime to ChatSessionManager's engineFactory so every
+ *      session engine shares the pool (same active model, same tool set).
+ *   5. Discard the seed engine — it will never run a task.
+ *
+ * Why this over pure "factor-out-builders" (approach b):
+ *   Engine.populateModelPoolFromSettings() is a 60-line private method that
+ *   reads settings, resolves the active key, builds the ProviderCatalog, and
+ *   reloads cached context windows. Extracting it as a standalone helper
+ *   would require making several private fields and imports public. The seed
+ *   engine pattern reuses the existing, tested code with zero API changes.
+ *
+ * Clients (Electron renderer, TUI) must not change. As long as the
+ * transport is stdio NDJSON and the protocol surface is unchanged, this
+ * bootstrap is invisible to them.
+ */
+
+import { Engine } from "../engine/engine.js";
+import { EngineRuntime } from "../engine/runtime.js";
+import { ChatSessionManager } from "../protocol/chat-session-manager.js";
+import { AgentServer } from "../protocol/server.js";
+import { StdioTransport } from "../protocol/transport.js";
+import { SettingsManager } from "../settings/manager.js";
+import { MCPManager } from "../tool-system/mcp-manager.js";
+import { CostTracker } from "../cost-tracker.js";
+
+// ─── Read base config from environment / settings ─────────────────
+
+const cwd = process.env.AGENT_CWD ?? process.cwd();
+
+// Load settings once to derive llm config for the seed engine.
+const settingsManager = new SettingsManager(cwd);
+const settings = settingsManager.get();
+
+const llmConfig = {
+  provider: settings.model.provider,
+  model: settings.model.name,
+  apiKey: settings.model.apiKey ?? "",
+  baseUrl: settings.model.baseUrl,
+  temperature: settings.model.temperature,
+  maxTokens: settings.model.maxTokens,
+};
+
+// ─── Step 1: seed engine — populates model pool from settings ─────
+
+const seedEngine = new Engine({
+  llm: llmConfig,
+  cwd,
+  // No runtime — Engine.populateModelPoolFromSettings() runs in ctor.
+});
+
+// ─── Step 2: extract shared resources ────────────────────────────
+
+const modelPool = seedEngine.getModelPool();
+const toolRegistry = seedEngine.getToolRegistry();
+
+// SettingsManager is constructed fresh so the runtime owns its instance.
+const sharedSettings = new SettingsManager(cwd);
+
+// MCPManager: not connected to any servers at bootstrap time.
+// Individual session engines will connect to mcpServers from their config.
+// This instance satisfies the EngineRuntime type requirement; it is a
+// no-op holder until an engineFactory caller opts to attach servers.
+const mcpPool = new MCPManager(toolRegistry);
+
+// CostTracker: shared across all sessions for aggregate tracking.
+const costTracker = new CostTracker();
+
+// ─── Step 3: build the shared EngineRuntime ───────────────────────
+
+const runtime = new EngineRuntime({
+  modelPool,
+  toolRegistry,
+  settings: sharedSettings,
+  mcpPool,
+  costTracker,
+});
+
+// ─── Step 4: ChatSessionManager ──────────────────────────────────
+
+const chatManager = new ChatSessionManager({
+  runtime,
+  engineFactory: (slice) =>
+    new Engine({
+      llm: llmConfig,
+      cwd,
+      runtime,
+      // Per-session overrides from the protocol request
+      permissionMode: slice.permissionMode,
+      preset: slice.preset,
+      customSystemPrompt: slice.customSystemPrompt,
+      appendSystemPrompt: slice.appendSystemPrompt,
+      maxTurns: slice.maxTurns,
+      maxContextTokens: slice.maxContextTokens,
+      ...(slice.cwd ? { cwd: slice.cwd } : {}),
+    }),
+  maxSessions: 16,
+  idleTtlMs: 30 * 60 * 1000,
+});
+chatManager.startIdleSweeper();
+
+// ─── Step 5: AgentServer over stdio ──────────────────────────────
+
+const stdioTransport = new StdioTransport(process.stdin, process.stdout);
+
+new AgentServer({
+  chatManager,
+  transport: stdioTransport,
+});
+
+// Keep the process alive — readline in StdioTransport holds the event loop.
+// On parent close / stdin EOF the process will exit naturally.

--- a/packages/core/src/cli/agent-server-stdio.ts
+++ b/packages/core/src/cli/agent-server-stdio.ts
@@ -69,16 +69,27 @@ const seedEngine = new Engine({
 const modelPool = seedEngine.getModelPool();
 const toolRegistry = seedEngine.getToolRegistry();
 
-// SettingsManager is constructed fresh so the runtime owns its instance.
-const sharedSettings = new SettingsManager(cwd);
+// Capture the seed engine's resolved llmConfig (post-populateModelPoolFromSettings).
+// This includes resolved provider/baseUrl/apiKey from settings.providers[].
+const resolvedLlmConfig = seedEngine.getConfig().llm;
+
+// Reuse the same SettingsManager instance for the runtime instead of constructing
+// a fresh one — avoids duplication and keeps the pattern cleaner.
+const sharedSettings = settingsManager;
 
 // MCPManager: not connected to any servers at bootstrap time.
 // Individual session engines will connect to mcpServers from their config.
 // This instance satisfies the EngineRuntime type requirement; it is a
 // no-op holder until an engineFactory caller opts to attach servers.
+// TODO(future) — currently a top-level placeholder. Future work: aggregate
+// MCP server connections across sessions instead of each session creating
+// its own MCPManager via Engine.run lazy init.
 const mcpPool = new MCPManager(toolRegistry);
 
 // CostTracker: shared across all sessions for aggregate tracking.
+// TODO(future) — shared across all sessions, but Engine doesn't yet read
+// runtime.costTracker. Future work: per-session cost accounting through
+// the shared runtime.
 const costTracker = new CostTracker();
 
 // ─── Step 3: build the shared EngineRuntime ───────────────────────
@@ -97,7 +108,7 @@ const chatManager = new ChatSessionManager({
   runtime,
   engineFactory: (slice) =>
     new Engine({
-      llm: llmConfig,
+      llm: resolvedLlmConfig,
       cwd,
       runtime,
       // Per-session overrides from the protocol request

--- a/packages/core/src/engine/engine.ts
+++ b/packages/core/src/engine/engine.ts
@@ -1142,12 +1142,9 @@ export class Engine {
       inputSchema: t.inputSchema,
     }));
 
-    const toolCtx: import("../tool-system/context.js").ToolContext = {
+    const toolCtx: ToolContext = {
+      ...this.buildToolContext(),
       cwd: opts.projectDir ?? process.cwd(),
-      llmConfig: this.config.llm,
-      toolRegistry: this.toolRegistry,
-      planMode: this.planMode,
-      engine: this,
     };
 
     const messages: Message[] = [{ role: "user", content: opts.userPrompt }];

--- a/packages/core/src/engine/engine.ts
+++ b/packages/core/src/engine/engine.ts
@@ -556,16 +556,10 @@ export class Engine {
     }
 
     const toolCtx: ToolContext = {
-      cwd,
-      llmConfig: this.config.llm,
-      modelPool: this.modelPool,
-      toolRegistry: this.toolRegistry,
-      askUser: this.config.askUser,
+      ...this.buildToolContext(),
       subAgentSpawner,
       sandbox: sandboxBackend,
-      isSubAgent: this.config.isSubAgent === true,
-      hooks: this.hooks,
-      planMode: this.planMode,
+      cwd,
     };
 
     logger.info("engine.run", {
@@ -1148,11 +1142,13 @@ export class Engine {
       inputSchema: t.inputSchema,
     }));
 
-    const toolCtx = {
+    const toolCtx: import("../tool-system/context.js").ToolContext = {
       cwd: opts.projectDir ?? process.cwd(),
       llmConfig: this.config.llm,
       toolRegistry: this.toolRegistry,
-    } as import("../tool-system/context.js").ToolContext;
+      planMode: this.planMode,
+      engine: this,
+    };
 
     const messages: Message[] = [{ role: "user", content: opts.userPrompt }];
     let writeBudget = MAX_WRITES;
@@ -1528,5 +1524,24 @@ export class Engine {
     } else {
       this.planMode = value;
     }
+  }
+
+  /**
+   * Build a base ToolContext for this Engine. Used by run() (which then
+   * overlays turn-specific fields like sandbox and subAgentSpawner) and
+   * by tests that want a ToolContext without a full run() cycle.
+   */
+  buildToolContext(): ToolContext {
+    return {
+      cwd: this.config.cwd ?? process.cwd(),
+      llmConfig: this.config.llm,
+      modelPool: this.modelPool,
+      toolRegistry: this.toolRegistry,
+      askUser: this.config.askUser,
+      isSubAgent: this.config.isSubAgent === true,
+      hooks: this.hooks,
+      planMode: this.planMode,
+      engine: this,
+    };
   }
 }

--- a/packages/core/src/engine/engine.ts
+++ b/packages/core/src/engine/engine.ts
@@ -535,6 +535,7 @@ export class Engine {
       sandbox: sandboxBackend,
       isSubAgent: this.config.isSubAgent === true,
       hooks: this.hooks,
+      planMode: false, // TODO(T6): replace with this.planMode once Engine.planMode is wired.
     };
 
     logger.info("engine.run", {

--- a/packages/core/src/engine/engine.ts
+++ b/packages/core/src/engine/engine.ts
@@ -366,7 +366,13 @@ export class Engine {
    * the same key overwrites them), so callers don't need to clear first.
    */
   reloadModelPool(): void {
-    this.populateModelPoolFromSettings();
+    // When sharing a runtime, the owner of the runtime is responsible
+    // for populating the pool; reloading from settings here would
+    // blast that owner's contributions and affect every other Engine
+    // that shares this runtime.
+    if (!this.runtime) {
+      this.populateModelPoolFromSettings();
+    }
   }
 
   /**
@@ -1514,12 +1520,13 @@ export class Engine {
    * Also syncs permissionMode to keep both fields consistent.
    */
   setPlanMode(value: boolean): void {
-    this.planMode = value;
     if (value) {
       this.setPermissionMode("plan");
     } else if (this.permissionMode === "plan") {
-      // Revert to default interactive mode when leaving plan mode.
+      // Leaving plan mode: drop back to the default.
       this.setPermissionMode("acceptEdits");
+    } else {
+      this.planMode = value;
     }
   }
 }

--- a/packages/core/src/engine/engine.ts
+++ b/packages/core/src/engine/engine.ts
@@ -64,6 +64,7 @@ import {
 } from "../onboarding.js";
 import { detectPastedNoise } from "../utils/task-sanitizer.js";
 import { MemoryOrchestrator } from "../services/memory-orchestrator.js";
+import { EngineRuntime } from "./runtime.js";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import {
@@ -120,6 +121,13 @@ export interface EngineConfig {
    * pool, the runtime check still blocks the call.
    */
   isSubAgent?: boolean;
+  /**
+   * Optional shared EngineRuntime providing pre-constructed shared resources
+   * (modelPool, toolRegistry, etc.). When provided, Engine uses these instead
+   * of constructing its own. Existing callers that omit this field continue to
+   * work unchanged — T11 will migrate them.
+   */
+  runtime?: EngineRuntime;
 }
 
 export interface EngineHookConfig {
@@ -144,6 +152,13 @@ export class Engine {
   private sessionManager: SessionManager;
   private mcpManager: MCPManager | undefined;
   private modelPool: ModelPool;
+
+  /** Shared resources supplied at construction (adapter pattern — null when self-constructed). */
+  readonly runtime: EngineRuntime | null;
+  /** Active permission mode for this Engine instance. */
+  permissionMode: NonNullable<EngineConfig["permissionMode"]>;
+  /** True when permissionMode === "plan". */
+  planMode: boolean;
 
   // Lazy SettingsManager — reused across updateConfig/readSetting so we
   // don't re-read 6+ JSON files on every /model, /login, etc. The manager
@@ -230,8 +245,15 @@ export class Engine {
   }
 
   constructor(private config: EngineConfig) {
+    // Wire shared runtime (adapter pattern — null when self-constructing).
+    this.runtime = config.runtime ?? null;
+
+    // Instance-level permission/plan mode fields.
+    this.permissionMode = config.permissionMode ?? "acceptEdits";
+    this.planMode = this.permissionMode === "plan";
+
     this.preset = resolveAgentPreset(config.preset);
-    this.toolRegistry = new ToolRegistry({
+    this.toolRegistry = config.runtime?.toolRegistry ?? new ToolRegistry({
       builtinTools: resolveBuiltinToolNames({
         preset: this.preset.name,
         enabledBuiltinTools: config.enabledBuiltinTools,
@@ -257,9 +279,11 @@ export class Engine {
     }
     this.sessionManager = new SessionManager(config.sessionStorageDir);
 
-    // Initialize model pool from settings
-    this.modelPool = new ModelPool();
-    this.populateModelPoolFromSettings();
+    // Initialize model pool — prefer runtime's shared pool, fall back to self-constructed.
+    this.modelPool = config.runtime?.modelPool ?? new ModelPool();
+    if (!config.runtime) {
+      this.populateModelPoolFromSettings();
+    }
   }
 
   /**
@@ -535,7 +559,7 @@ export class Engine {
       sandbox: sandboxBackend,
       isSubAgent: this.config.isSubAgent === true,
       hooks: this.hooks,
-      planMode: false, // TODO(T6): replace with this.planMode once Engine.planMode is wired.
+      planMode: this.planMode,
     };
 
     logger.info("engine.run", {
@@ -1472,6 +1496,8 @@ export class Engine {
    */
   setPermissionMode(mode: NonNullable<EngineConfig["permissionMode"]>): void {
     this.config = { ...this.config, permissionMode: mode };
+    this.permissionMode = mode;
+    this.planMode = mode === "plan";
     if (this.activePermission) {
       const cwd = this.config.cwd ?? process.cwd();
       const { rules, backend } = this.buildPermissionConfig(mode, cwd);
@@ -1481,5 +1507,19 @@ export class Engine {
 
   getPermissionMode(): NonNullable<EngineConfig["permissionMode"]> {
     return this.config.permissionMode ?? "acceptEdits";
+  }
+
+  /**
+   * Toggle plan mode directly. Called by the Plan tool (Task 7) via ToolContext.engine.
+   * Also syncs permissionMode to keep both fields consistent.
+   */
+  setPlanMode(value: boolean): void {
+    this.planMode = value;
+    if (value) {
+      this.setPermissionMode("plan");
+    } else if (this.permissionMode === "plan") {
+      // Revert to default interactive mode when leaving plan mode.
+      this.setPermissionMode("acceptEdits");
+    }
   }
 }

--- a/packages/core/src/engine/engine.ts
+++ b/packages/core/src/engine/engine.ts
@@ -41,7 +41,6 @@ import { recordSessionStart, recordSessionEnd } from "../logging/session-recorde
 import { TurnLoop, type TurnLoopConfig } from "./turn-loop.js";
 import type { AskUserFn } from "../tool-system/builtin/ask-user.js";
 import { MCPManager } from "../tool-system/mcp-manager.js";
-import { isInPlanMode } from "../tool-system/builtin/plan.js";
 import { SettingsManager } from "../settings/manager.js";
 import { FileHistory } from "../session/file-history.js";
 import type { ToolContext, SubAgentSpawner } from "../tool-system/context.js";
@@ -758,7 +757,7 @@ export class Engine {
       "TaskGet",
       "Bash", // Bash is included but executor filters non-read-only commands
     ]);
-    const toolDefs = isInPlanMode()
+    const toolDefs = this.planMode
       ? allToolDefs.filter((t) => planModeAllowed.has(t.name))
       : allToolDefs;
 

--- a/packages/core/src/engine/runtime.ts
+++ b/packages/core/src/engine/runtime.ts
@@ -1,7 +1,15 @@
 import type { ModelPool } from "../llm/model-pool.js";
+import type { ToolRegistry } from "../tool-system/registry.js";
+import type { SettingsManager } from "../settings/manager.js";
+import type { MCPManager } from "../tool-system/mcp-manager.js";
+import type { CostTracker } from "../cost-tracker.js";
 
 export interface EngineRuntimeOptions {
   modelPool: ModelPool;
+  toolRegistry: ToolRegistry;
+  settings: SettingsManager;
+  mcpPool: MCPManager;
+  costTracker: CostTracker;
 }
 
 /**
@@ -10,8 +18,16 @@ export interface EngineRuntimeOptions {
  */
 export class EngineRuntime {
   readonly modelPool: ModelPool;
+  readonly toolRegistry: ToolRegistry;
+  readonly settings: SettingsManager;
+  readonly mcpPool: MCPManager;
+  readonly costTracker: CostTracker;
 
   constructor(opts: EngineRuntimeOptions) {
     this.modelPool = opts.modelPool;
+    this.toolRegistry = opts.toolRegistry;
+    this.settings = opts.settings;
+    this.mcpPool = opts.mcpPool;
+    this.costTracker = opts.costTracker;
   }
 }

--- a/packages/core/src/engine/runtime.ts
+++ b/packages/core/src/engine/runtime.ts
@@ -1,0 +1,17 @@
+import type { ModelPool } from "../llm/model-pool.js";
+
+export interface EngineRuntimeOptions {
+  modelPool: ModelPool;
+}
+
+/**
+ * Shared read-only resources used by all Engine instances in a worker.
+ * Mutable per-session state stays on Engine itself.
+ */
+export class EngineRuntime {
+  readonly modelPool: ModelPool;
+
+  constructor(opts: EngineRuntimeOptions) {
+    this.modelPool = opts.modelPool;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,10 @@ export {
 export { Engine } from "./engine/engine.js";
 export type { EngineConfig, EngineHookConfig, EngineResult } from "./engine/engine.js";
 export type { CostStateStore, CostStateSnapshot } from "./engine/cost-store.js";
+export { EngineRuntime } from "./engine/runtime.js";
+export type { EngineRuntimeOptions } from "./engine/runtime.js";
+export { ChatSessionManager } from "./protocol/chat-session-manager.js";
+export type { ChatSessionManagerOptions } from "./protocol/chat-session-manager.js";
 
 // ─── LLM ─────────────────────────────────────────────────────────
 
@@ -407,7 +411,7 @@ export { recordUIEvent } from "./logging/session-recorder.js";
 
 // ─── Cost Tracker ────────────────────────────────────────────────
 
-export { costTracker, installCostTracking } from "./cost-tracker.js";
+export { CostTracker, costTracker, installCostTracking } from "./cost-tracker.js";
 export { NOOP_COLORIZER, type Colorizer } from "./colorizer.js";
 
 // ─── Onboarding ──────────────────────────────────────────────────

--- a/packages/core/src/protocol/chat-session-manager.ts
+++ b/packages/core/src/protocol/chat-session-manager.ts
@@ -15,6 +15,11 @@ export type EngineConfigSlice = Pick<
 >;
 
 export interface ChatSessionManagerOptions {
+  /**
+   * Shared runtime, supplied here so callers and engineFactory closures
+   * derived from these options can reference one canonical instance. The
+   * manager itself does not retain it — engineFactory captures it via closure.
+   */
   runtime: EngineRuntime;
   /** Build an Engine. Tests inject a fake; production passes (cfg) => new Engine({ runtime, ...cfg }). */
   engineFactory: (slice: EngineConfigSlice) => Engine;
@@ -24,14 +29,12 @@ export interface ChatSessionManagerOptions {
 
 export class ChatSessionManager {
   private readonly sessions = new Map<string, ChatSession>();
-  private readonly runtime: EngineRuntime;
   private readonly factory: (slice: EngineConfigSlice) => Engine;
   private readonly maxSessions: number;
   private readonly idleTtlMs: number;
   private sweeper: ReturnType<typeof setInterval> | null = null;
 
   constructor(opts: ChatSessionManagerOptions) {
-    this.runtime = opts.runtime;
     this.factory = opts.engineFactory;
     this.maxSessions = opts.maxSessions ?? 16;
     this.idleTtlMs = opts.idleTtlMs ?? 30 * 60 * 1000;
@@ -75,7 +78,7 @@ export class ChatSessionManager {
 
   sweepIdle(): void {
     const cutoff = Date.now() - this.idleTtlMs;
-    for (const [id, s] of this.sessions) {
+    for (const [id, s] of [...this.sessions]) {
       if (s.lastActivityAt < cutoff && !s.isBusy()) this.close(id);
     }
   }

--- a/packages/core/src/protocol/chat-session-manager.ts
+++ b/packages/core/src/protocol/chat-session-manager.ts
@@ -1,0 +1,94 @@
+import { ChatSession } from "./chat-session.js";
+import type { Engine } from "../engine/engine.js";
+import type { EngineRuntime } from "../engine/runtime.js";
+import type { EngineConfig } from "../engine/engine.js";
+
+export type EngineConfigSlice = Pick<
+  EngineConfig,
+  | "permissionMode"
+  | "preset"
+  | "customSystemPrompt"
+  | "appendSystemPrompt"
+  | "maxTurns"
+  | "maxContextTokens"
+  | "cwd"
+>;
+
+export interface ChatSessionManagerOptions {
+  runtime: EngineRuntime;
+  /** Build an Engine. Tests inject a fake; production passes (cfg) => new Engine({ runtime, ...cfg }). */
+  engineFactory: (slice: EngineConfigSlice) => Engine;
+  maxSessions?: number;   // default 16
+  idleTtlMs?: number;     // default 30 min
+}
+
+export class ChatSessionManager {
+  private readonly sessions = new Map<string, ChatSession>();
+  private readonly runtime: EngineRuntime;
+  private readonly factory: (slice: EngineConfigSlice) => Engine;
+  private readonly maxSessions: number;
+  private readonly idleTtlMs: number;
+  private sweeper: ReturnType<typeof setInterval> | null = null;
+
+  constructor(opts: ChatSessionManagerOptions) {
+    this.runtime = opts.runtime;
+    this.factory = opts.engineFactory;
+    this.maxSessions = opts.maxSessions ?? 16;
+    this.idleTtlMs = opts.idleTtlMs ?? 30 * 60 * 1000;
+  }
+
+  getOrCreate(sessionId: string, slice: EngineConfigSlice): ChatSession {
+    const existing = this.sessions.get(sessionId);
+    if (existing) {
+      existing.lastActivityAt = Date.now();
+      return existing;
+    }
+    if (this.sessions.size >= this.maxSessions) {
+      const err = new Error(`Overloaded: maxSessions=${this.maxSessions} reached`);
+      (err as any).code = -32001;
+      throw err;
+    }
+    const engine = this.factory(slice);
+    const session = new ChatSession({ id: sessionId, engine });
+    this.sessions.set(sessionId, session);
+    return session;
+  }
+
+  get(sessionId: string): ChatSession | undefined {
+    return this.sessions.get(sessionId);
+  }
+
+  close(sessionId: string): void {
+    const s = this.sessions.get(sessionId);
+    if (!s) return;
+    s.cancel();
+    this.sessions.delete(sessionId);
+  }
+
+  closeAll(): void {
+    for (const id of [...this.sessions.keys()]) this.close(id);
+  }
+
+  sessionCount(): number {
+    return this.sessions.size;
+  }
+
+  sweepIdle(): void {
+    const cutoff = Date.now() - this.idleTtlMs;
+    for (const [id, s] of this.sessions) {
+      if (s.lastActivityAt < cutoff && !s.isBusy()) this.close(id);
+    }
+  }
+
+  startIdleSweeper(intervalMs = 60_000): void {
+    if (this.sweeper) return;
+    this.sweeper = setInterval(() => this.sweepIdle(), intervalMs);
+    // Allow the process to exit even if sweeper is pending.
+    (this.sweeper as any)?.unref?.();
+  }
+
+  stopIdleSweeper(): void {
+    if (this.sweeper) clearInterval(this.sweeper);
+    this.sweeper = null;
+  }
+}

--- a/packages/core/src/protocol/chat-session.ts
+++ b/packages/core/src/protocol/chat-session.ts
@@ -1,0 +1,92 @@
+import type { Engine, EngineResult } from "../engine/engine.js";
+import type { StreamEvent } from "../types.js";
+
+export interface ChatSessionOptions {
+  id: string;
+  engine: Engine;
+  onStream?: (event: StreamEvent) => void;
+}
+
+export interface TurnOpts {
+  cwd?: string;
+  onStream?: (event: StreamEvent) => void;
+}
+
+interface QueuedTurn {
+  task: string;
+  opts: TurnOpts;
+  resolve: (r: EngineResult) => void;
+  reject: (e: unknown) => void;
+}
+
+/**
+ * One ChatSession per UI chat tab. Owns a single Engine, an AbortController
+ * for the active turn, and a FIFO queue so a fast second send waits for the
+ * first turn to finish instead of being silently rejected.
+ */
+export class ChatSession {
+  readonly id: string;
+  readonly engine: Engine;
+  readonly pendingApprovals = new Map<string, (decision: unknown) => void>();
+  lastActivityAt = Date.now();
+
+  private queue: QueuedTurn[] = [];
+  private active: QueuedTurn | null = null;
+  private controller: AbortController | null = null;
+  private readonly defaultOnStream?: (event: StreamEvent) => void;
+
+  constructor(opts: ChatSessionOptions) {
+    this.id = opts.id;
+    this.engine = opts.engine;
+    this.defaultOnStream = opts.onStream;
+  }
+
+  enqueueTurn(task: string, opts: TurnOpts): Promise<EngineResult> {
+    this.lastActivityAt = Date.now();
+    return new Promise((resolve, reject) => {
+      this.queue.push({ task, opts, resolve, reject });
+      this.pump();
+    });
+  }
+
+  cancel(): void {
+    this.controller?.abort();
+    // Drain queued turns as cancelled
+    const drained = this.queue.splice(0);
+    for (const t of drained) {
+      t.reject(new Error("cancelled: session aborted before turn ran"));
+    }
+  }
+
+  isBusy(): boolean {
+    return this.active !== null;
+  }
+
+  queueDepth(): number {
+    return this.queue.length;
+  }
+
+  private async pump(): Promise<void> {
+    if (this.active) return;
+    const next = this.queue.shift();
+    if (!next) return;
+    this.active = next;
+    this.controller = new AbortController();
+    try {
+      const onStream = next.opts.onStream ?? this.defaultOnStream;
+      const result = await this.engine.run(next.task, {
+        signal: this.controller.signal,
+        onStream,
+      });
+      this.lastActivityAt = Date.now();
+      next.resolve(result);
+    } catch (err) {
+      next.reject(err);
+    } finally {
+      this.active = null;
+      this.controller = null;
+      // Drain the next turn if one is waiting.
+      if (this.queue.length > 0) void this.pump();
+    }
+  }
+}

--- a/packages/core/src/protocol/chat-session.ts
+++ b/packages/core/src/protocol/chat-session.ts
@@ -89,6 +89,7 @@ export class ChatSession {
     try {
       const onStream = next.opts.onStream ?? this.defaultOnStream;
       const result = await this.engine.run(next.task, {
+        sessionId: this.id,
         signal: this.controller.signal,
         onStream,
       });

--- a/packages/core/src/protocol/chat-session.ts
+++ b/packages/core/src/protocol/chat-session.ts
@@ -8,7 +8,6 @@ export interface ChatSessionOptions {
 }
 
 export interface TurnOpts {
-  cwd?: string;
   onStream?: (event: StreamEvent) => void;
 }
 
@@ -27,6 +26,13 @@ interface QueuedTurn {
 export class ChatSession {
   readonly id: string;
   readonly engine: Engine;
+  /**
+   * Per-session approval callbacks indexed by tool-call requestId.
+   * `readonly` guards the Map reference (preventing reassignment); the
+   * contents are mutated by `.set()` / `.delete()` as approvals come and go.
+   * Task 10 will register entries here when the Engine raises an approval
+   * request and clean them up on response.
+   */
   readonly pendingApprovals = new Map<string, (decision: unknown) => void>();
   lastActivityAt = Date.now();
 
@@ -49,6 +55,14 @@ export class ChatSession {
     });
   }
 
+  /**
+   * Abort the in-flight turn and drain queued turns.
+   *
+   * Relies on `engine.run()` honouring the `AbortSignal`. If `engine.run` were
+   * to swallow the abort and resolve successfully, the caller of the in-flight
+   * `enqueueTurn` would observe success — not a cancellation. The queued turns
+   * are always rejected regardless.
+   */
   cancel(): void {
     this.controller?.abort();
     // Drain queued turns as cancelled

--- a/packages/core/src/protocol/client.ts
+++ b/packages/core/src/protocol/client.ts
@@ -17,6 +17,7 @@ import {
   type RpcNotification,
   type RunParams,
   type RunResult,
+  type AgentStreamEventNotification,
   type ConfigureParams,
   type QueryParams,
   type QueryResult,
@@ -32,7 +33,8 @@ import { logger } from "../logging/logger.js";
 // ─── Event Types ────────────────────────────────────────────────────
 
 export interface AgentClientEvents {
-  stream: (event: StreamEvent) => void;
+  /** Multi-session envelope: carries sessionId + event. */
+  stream: (envelope: AgentStreamEventNotification) => void;
   approvalRequest: (requestId: string, request: ApprovalRequest) => void;
   status: (status: string, message?: string) => void;
 }
@@ -67,15 +69,21 @@ export class AgentClient {
   /**
    * Run an agent task. Resolves when the agent completes.
    * Stream events arrive via the onStreamEvent callback.
+   *
+   * Accepts either the new object form `{ sessionId, task, ... }` (required
+   * for multi-session servers) or the legacy string form `(task, sessionId?)`
+   * for backward compatibility with createInProcessClient callers.
    */
-  async run(task: string, sessionId?: string): Promise<RunResult> {
-    const params: RunParams = { task, sessionId };
-    // If the caller provided a session id, stamp it on the logger eagerly
-    // so client-side log lines emitted during this run (before the server
-    // response arrives) carry the right sid. The server-resolved id from
-    // the response below takes precedence — they only differ on the
-    // first call of a brand-new session, when sessionId is undefined.
-    if (sessionId) logger.setSid(sessionId);
+  async run(taskOrParams: string | RunParams, sessionId?: string): Promise<RunResult> {
+    let params: RunParams;
+    if (typeof taskOrParams === "string") {
+      // Legacy string form — sessionId is optional (single-engine server)
+      params = { task: taskOrParams, sessionId: sessionId ?? "" } as RunParams;
+    } else {
+      params = taskOrParams;
+    }
+    // Stamp logger eagerly if sessionId is known
+    if (params.sessionId) logger.setSid(params.sessionId);
     const result = (await this.request(
       Methods.Run,
       params as unknown as Record<string, unknown>,
@@ -159,11 +167,16 @@ export class AgentClient {
 
   // ─── Event Handlers ─────────────────────────────────────────────
 
-  onStreamEvent(handler: (event: StreamEvent) => void): void {
+  /**
+   * Register a handler for stream event notifications.
+   * The handler receives the full envelope `{ sessionId, event }` so callers
+   * can route events to the correct tab/session.
+   */
+  onStreamEvent(handler: (envelope: AgentStreamEventNotification) => void): void {
     this.emitter.on("stream", handler);
   }
 
-  offStreamEvent(handler: (event: StreamEvent) => void): void {
+  offStreamEvent(handler: (envelope: AgentStreamEventNotification) => void): void {
     this.emitter.off("stream", handler);
   }
 
@@ -200,7 +213,12 @@ export class AgentClient {
     this.pendingRequests.delete(res.id);
 
     if (res.error) {
-      pending.reject(new Error(`[${res.error.code}] ${res.error.message}`));
+      // Attach both message and code so callers can do toMatchObject({ code }).
+      const err = new Error(`[${res.error.code}] ${res.error.message}`) as Error & {
+        code: number;
+      };
+      err.code = res.error.code;
+      pending.reject(err);
     } else {
       pending.resolve(res.result);
     }
@@ -212,7 +230,11 @@ export class AgentClient {
     switch (notif.method) {
       case Methods.StreamEvent: {
         const event = params.event as StreamEvent | undefined;
-        if (event) this.emitter.emit("stream", event);
+        const sessionId = (params.sessionId as string | undefined) ?? "";
+        if (event) {
+          const envelope: AgentStreamEventNotification = { sessionId, event };
+          this.emitter.emit("stream", envelope);
+        }
         break;
       }
       case Methods.ApprovalRequest: {

--- a/packages/core/src/protocol/client.ts
+++ b/packages/core/src/protocol/client.ts
@@ -94,19 +94,36 @@ export class AgentClient {
 
   /**
    * Respond to an approval request from the server.
+   *
+   * Multi-session form: approve(sessionId, requestId, decision)
+   * Legacy form:        approve(requestId, decision)
    */
-  async approve(requestId: string, decision: ApprovalResult): Promise<void> {
-    await this.request(Methods.Approve, { requestId, decision } as unknown as Record<
-      string,
-      unknown
-    >);
+  approve(sessionId: string, requestId: string, decision: ApprovalResult): Promise<void>;
+  approve(requestId: string, decision: ApprovalResult): Promise<void>;
+  approve(...args: unknown[]): Promise<void> {
+    if (args.length === 3) {
+      const [sessionId, requestId, decision] = args as [string, string, ApprovalResult];
+      return this.request(Methods.Approve, {
+        sessionId,
+        requestId,
+        decision,
+      } as unknown as Record<string, unknown>) as Promise<void>;
+    }
+    const [requestId, decision] = args as [string, ApprovalResult];
+    return this.request(Methods.Approve, {
+      requestId,
+      decision,
+    } as unknown as Record<string, unknown>) as Promise<void>;
   }
 
   /**
    * Cancel a running agent.
+   *
+   * Multi-session form: cancel(sessionId, reason?)
+   * Legacy form:        cancel(reason?)
    */
-  async cancel(reason?: string): Promise<void> {
-    await this.request(Methods.Cancel, { reason } as Record<string, unknown>);
+  async cancel(sessionId?: string, reason?: string): Promise<void> {
+    await this.request(Methods.Cancel, { sessionId, reason } as Record<string, unknown>);
   }
 
   /**

--- a/packages/core/src/protocol/helpers.ts
+++ b/packages/core/src/protocol/helpers.ts
@@ -54,7 +54,8 @@ export function createInProcessClient(
   const client = new AgentClient({ transport: clientTransport });
 
   if (options.onStream) {
-    client.onStreamEvent(options.onStream);
+    const cb = options.onStream;
+    client.onStreamEvent((envelope) => cb(envelope.event));
   }
 
   let closed = false;

--- a/packages/core/src/protocol/server.ts
+++ b/packages/core/src/protocol/server.ts
@@ -1,11 +1,17 @@
 /**
- * AgentServer — wraps Engine and exposes it over the protocol.
+ * AgentServer — wraps ChatSessionManager and exposes it over the protocol.
  *
  * Responsibilities:
  *   - Handles RPC requests from the client (run, approve, cancel, configure, query)
- *   - Forwards StreamEvents to the client as notifications
- *   - Manages approval flow: engine → server → client → server → engine
- *   - Owns all mutable runtime state (plan mode, bypass, etc.)
+ *   - Forwards StreamEvents to the client as notifications with sessionId envelope
+ *   - Manages per-session approval flow
+ *   - Dispatches agent/run through ChatSessionManager so multiple sessions
+ *     run concurrently without cross-talk
+ *
+ * Backward compat: an optional `engine` can be supplied for global operations
+ * (model list, config reads/writes, tool registry queries, etc.) that don't
+ * yet have a natural "which session" answer. When not supplied the server
+ * falls back to borrowing any live session's engine for those reads.
  */
 
 import type { Transport } from "./transport.js";
@@ -14,7 +20,6 @@ import {
   type RunParams,
   type RunResult,
   type ApproveParams,
-  type CancelParams,
   type ConfigureParams,
   type QueryParams,
   type InjectParams,
@@ -31,19 +36,32 @@ import { setInteractiveApprovalFn } from "../tool-system/permission.js";
 import { getArenaStatus } from "../tool-system/builtin/arena.js";
 import { taskManager } from "../tool-system/builtin/task.js";
 import { nanoid } from "nanoid";
+import type { ChatSessionManager } from "./chat-session-manager.js";
 
 export interface AgentServerOptions {
-  engine: Engine;
+  /**
+   * Multi-session manager. Required for the new multi-session protocol.
+   * When present, agent/run dispatches through the manager.
+   */
+  chatManager?: ChatSessionManager;
+  /**
+   * Legacy single-engine mode. When chatManager is not supplied the server
+   * falls back to the old single-engine behaviour (backwards compat for
+   * createInProcessClient and agent-server-stdio until T11).
+   */
+  engine?: Engine;
   transport: Transport;
 }
 
 export class AgentServer {
-  private engine: Engine;
+  private readonly chatManager: ChatSessionManager | null;
+  private readonly legacyEngine: Engine | null;
   private transport: Transport;
+
+  // ── Legacy single-engine state (used when chatManager is null) ──
   private running = false;
   private abortController: AbortController | null = null;
-
-  /** Pending approval requests: requestId → resolve function */
+  /** Pending approval requests: requestId → resolve function (legacy path) */
   private pendingApprovals = new Map<string, (result: ApprovalResult) => void>();
   /** Timers for approval timeouts */
   private approvalTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -51,7 +69,13 @@ export class AgentServer {
   private static readonly APPROVAL_TIMEOUT_MS = 5 * 60 * 1000;
 
   constructor(options: AgentServerOptions) {
-    this.engine = options.engine;
+    this.chatManager = options.chatManager ?? null;
+    this.legacyEngine = options.engine ?? null;
+
+    if (!this.chatManager && !this.legacyEngine) {
+      throw new Error("AgentServer: either chatManager or engine must be supplied");
+    }
+
     this.transport = options.transport;
 
     // Wire up incoming messages
@@ -65,16 +89,18 @@ export class AgentServer {
       }
     });
 
-    // Wire approval flow: engine asks server, server asks client
-    setInteractiveApprovalFn((request: ApprovalRequest) => {
-      return this.requestApprovalFromClient(request);
-    });
+    // Wire approval flow for the legacy single-engine path.
+    // In the chatManager path approval flows are per-session and registered
+    // when the session's engine raises an approval request via onStream.
+    if (this.legacyEngine) {
+      setInteractiveApprovalFn((request: ApprovalRequest) => {
+        return this.requestApprovalFromClient(request);
+      });
 
-    // Wire askUser: install a protocol-backed askUser handler on the engine
-    // (replaces the legacy setAskUserFn module singleton).
-    this.engine.setAskUser((question, opts) => {
-      return this.requestAskUserFromClient(question, opts);
-    });
+      this.legacyEngine.setAskUser((question, opts) => {
+        return this.requestAskUserFromClient(question, opts);
+      });
+    }
 
     // Notify client we're ready
     this.notify(Methods.Status, { status: "ready" });
@@ -97,10 +123,13 @@ export class AgentServer {
         this.handleConfigure(req);
         break;
       case Methods.Query:
-        this.handleQuery(req);
+        await this.handleQuery(req);
         break;
       case Methods.Inject:
         this.handleInject(req);
+        break;
+      case Methods.CloseSession:
+        this.handleCloseSession(req);
         break;
       default:
         this.transport.send(
@@ -112,9 +141,73 @@ export class AgentServer {
   // ─── Run ────────────────────────────────────────────────────────
 
   private async handleRun(req: RpcRequest): Promise<void> {
+    // ── ChatSessionManager path (multi-session) ──────────────────
+    if (this.chatManager) {
+      return this.handleRunMulti(req);
+    }
+    // ── Legacy single-engine path ────────────────────────────────
+    return this.handleRunLegacy(req);
+  }
+
+  private async handleRunMulti(req: RpcRequest): Promise<void> {
+    const cm = this.chatManager!;
+    const params = (req.params ?? {}) as unknown as RunParams;
+
+    if (typeof params.sessionId !== "string" || params.sessionId.length === 0) {
+      this.transport.send(
+        createErrorResponse(req.id, ErrorCodes.InvalidParams, "sessionId is required"),
+      );
+      return;
+    }
+    if (!params.task) {
+      this.transport.send(
+        createErrorResponse(req.id, ErrorCodes.InvalidParams, "task is required"),
+      );
+      return;
+    }
+
+    let session;
+    try {
+      session = cm.getOrCreate(params.sessionId, {
+        permissionMode: params.permissionMode,
+        cwd: params.cwd,
+      } as any);
+    } catch (err: any) {
+      const code = err.code ?? ErrorCodes.InternalError;
+      this.transport.send(createErrorResponse(req.id, code, err.message));
+      return;
+    }
+
+    if (typeof params.planMode === "boolean") {
+      session.engine.setPlanMode(params.planMode);
+    }
+
+    const sid = params.sessionId;
+    try {
+      const result = await session.enqueueTurn(params.task, {
+        onStream: (event: StreamEvent) =>
+          this.notify(Methods.StreamEvent, { sessionId: sid, event }),
+      });
+
+      const runResult: RunResult = {
+        text: result.text,
+        reason: result.reason,
+        sessionId: result.sessionId ?? sid,
+        turnCount: result.turnCount,
+        usage: result.usage,
+      };
+      this.transport.send(createResponse(req.id, runResult));
+    } catch (err) {
+      this.transport.send(
+        createErrorResponse(req.id, ErrorCodes.InternalError, (err as Error).message),
+      );
+    }
+  }
+
+  private async handleRunLegacy(req: RpcRequest): Promise<void> {
     if (this.running) {
       this.transport.send(
-        createErrorResponse(req.id, ErrorCodes.AlreadyRunning, "Agent is already running"),
+        createErrorResponse(req.id, ErrorCodes.Overloaded, "Agent is already running"),
       );
       return;
     }
@@ -132,18 +225,13 @@ export class AgentServer {
     this.notify(Methods.Status, { status: "running" });
 
     const streamToClient = (event: StreamEvent) => {
-      this.notify(Methods.StreamEvent, { event });
+      this.notify(Methods.StreamEvent, { sessionId: params.sessionId ?? "", event });
     };
 
-    // Wire the global TaskManager into this run's stream so TaskCreate /
-    // TaskUpdate calls — from the main agent OR any spawned sub-agent —
-    // surface as task_update events the UI's top panel listens for.
-    // The manager is a module singleton, so a single registration here
-    // covers nested engine.run() calls; we tear it down in finally.
     taskManager.setStreamCallback(streamToClient);
 
     try {
-      const result = await this.engine.run(params.task, {
+      const result = await this.legacyEngine!.run(params.task, {
         sessionId: params.sessionId,
         signal: this.abortController!.signal,
         onStream: streamToClient,
@@ -174,8 +262,39 @@ export class AgentServer {
 
   private handleApprove(req: RpcRequest): void {
     const params = (req.params ?? {}) as unknown as ApproveParams;
-    const resolve = this.pendingApprovals.get(params.requestId);
 
+    // ChatSessionManager path: look up per-session pendingApprovals
+    if (this.chatManager && typeof params.sessionId === "string") {
+      const s = this.chatManager.get(params.sessionId);
+      if (!s) {
+        this.transport.send(
+          createErrorResponse(
+            req.id,
+            ErrorCodes.SessionClosed,
+            `No such session: ${params.sessionId}`,
+          ),
+        );
+        return;
+      }
+      const resolve = s.pendingApprovals.get(params.requestId);
+      if (!resolve) {
+        this.transport.send(
+          createErrorResponse(
+            req.id,
+            ErrorCodes.InvalidParams,
+            `No pending approval: ${params.requestId}`,
+          ),
+        );
+        return;
+      }
+      s.pendingApprovals.delete(params.requestId);
+      resolve(params.decision);
+      this.transport.send(createResponse(req.id, { ok: true }));
+      return;
+    }
+
+    // Legacy path
+    const resolve = this.pendingApprovals.get(params.requestId);
     if (!resolve) {
       this.transport.send(
         createErrorResponse(
@@ -196,17 +315,43 @@ export class AgentServer {
   // ─── Cancel ─────────────────────────────────────────────────────
 
   private handleCancel(req: RpcRequest): void {
+    const params = (req.params ?? {}) as unknown as import("./types.js").CancelParams;
+
+    // ChatSessionManager path: cancel a specific session
+    if (this.chatManager) {
+      if (typeof params.sessionId !== "string" || params.sessionId.length === 0) {
+        this.transport.send(
+          createErrorResponse(req.id, ErrorCodes.InvalidParams, "sessionId is required"),
+        );
+        return;
+      }
+      const s = this.chatManager.get(params.sessionId);
+      if (!s) {
+        this.transport.send(
+          createErrorResponse(
+            req.id,
+            ErrorCodes.SessionClosed,
+            `No such session: ${params.sessionId}`,
+          ),
+        );
+        return;
+      }
+      s.cancel();
+      this.transport.send(createResponse(req.id, { ok: true }));
+      return;
+    }
+
+    // Legacy path
     if (!this.running || !this.abortController) {
       this.transport.send(
-        createErrorResponse(req.id, ErrorCodes.NotRunning, "Agent is not running"),
+        createErrorResponse(req.id, ErrorCodes.SessionClosed, "Agent is not running"),
       );
       return;
     }
 
     this.abortController.abort();
 
-    // Reject all pending approvals
-    for (const [id, resolve] of this.pendingApprovals) {
+    for (const [, resolve] of this.pendingApprovals) {
       resolve({ approved: false, reason: "cancelled" });
     }
     this.pendingApprovals.clear();
@@ -215,22 +360,52 @@ export class AgentServer {
     this.transport.send(createResponse(req.id, { ok: true }));
   }
 
+  // ─── CloseSession ───────────────────────────────────────────────
+
+  private handleCloseSession(req: RpcRequest): void {
+    const params = (req.params ?? {}) as unknown as import("./types.js").CloseSessionParams;
+    if (typeof params.sessionId !== "string" || params.sessionId.length === 0) {
+      this.transport.send(
+        createErrorResponse(req.id, ErrorCodes.InvalidParams, "sessionId is required"),
+      );
+      return;
+    }
+    if (this.chatManager) {
+      this.chatManager.close(params.sessionId);
+    }
+    this.transport.send(createResponse(req.id, { ok: true }));
+  }
+
   // ─── Configure ──────────────────────────────────────────────────
 
   private handleConfigure(req: RpcRequest): void {
     const params = (req.params ?? {}) as unknown as ConfigureParams;
 
-    if (params.planMode !== undefined) {
-      // TODO(T6): once Engine exposes setPlanMode(), call this.engine.setPlanMode(params.planMode).
-      // For now, plan-mode toggling via Configure is a no-op until T6 wires Engine.planMode.
+    // If a sessionId is present, mutate that specific session's engine
+    if (this.chatManager && typeof (params as any).sessionId === "string") {
+      const sid = (params as any).sessionId as string;
+      const s = this.chatManager.get(sid);
+      if (!s) {
+        this.transport.send(
+          createErrorResponse(req.id, ErrorCodes.SessionClosed, `No such session: ${sid}`),
+        );
+        return;
+      }
+      if (typeof params.planMode === "boolean") s.engine.setPlanMode(params.planMode);
+      if (typeof params.permissionMode === "string") {
+        s.engine.setPermissionMode(params.permissionMode as NonNullable<EngineConfig["permissionMode"]>);
+      }
+      this.transport.send(createResponse(req.id, { ok: true }));
+      return;
     }
-    // TODO(T10): wire params.bypassPermissions through Engine.permissionMode once
-    // handleConfigure is rewritten in T10.
-    if (params.reloadModels) {
-      // Pick up newly persisted providers[]/models[] (e.g. from /login)
-      // before any model-key switch below tries to find them.
+
+    // Global configure — delegate to legacyEngine if available,
+    // or to any session's engine from chatManager for settings ops
+    const engine = this.legacyEngine ?? this.anyEngine();
+
+    if (params.reloadModels && engine) {
       try {
-        this.engine.reloadModelPool();
+        engine.reloadModelPool();
       } catch (err) {
         this.transport.send(
           createErrorResponse(req.id, ErrorCodes.InternalError, (err as Error).message),
@@ -238,9 +413,9 @@ export class AgentServer {
         return;
       }
     }
-    if (params.model !== undefined) {
+    if (params.model !== undefined && engine) {
       try {
-        const entry = this.engine.switchModel(params.model);
+        const entry = engine.switchModel(params.model);
         this.transport.send(
           createResponse(req.id, { ok: true, model: entry.model, key: entry.key }),
         );
@@ -252,8 +427,9 @@ export class AgentServer {
         return;
       }
     }
-    // permissionMode and effort are stored but need engine-level support
-    // to change mid-session — for now we accept and acknowledge
+    if (params.planMode !== undefined && engine) {
+      engine.setPlanMode(params.planMode);
+    }
 
     this.transport.send(createResponse(req.id, { ok: true }));
   }
@@ -262,12 +438,19 @@ export class AgentServer {
 
   private async handleQuery(req: RpcRequest): Promise<void> {
     const params = (req.params ?? {}) as unknown as QueryParams;
+    // For query operations we prefer the legacyEngine; if absent borrow any
+    // session engine from the manager (model pool, settings are shared).
+    const engine = this.legacyEngine ?? this.anyEngine();
 
     switch (params.type) {
       case "tools": {
-        const registry = this.engine.getToolRegistry();
-        // listToolsDetailed() returns objects with name/description,
-        // listTools() returns just names — use detailed if available
+        if (!engine) {
+          this.transport.send(
+            createErrorResponse(req.id, ErrorCodes.InternalError, "No engine available for tools query"),
+          );
+          return;
+        }
+        const registry = engine.getToolRegistry();
         const tools =
           typeof registry.listToolsDetailed === "function"
             ? registry
@@ -278,19 +461,39 @@ export class AgentServer {
         break;
       }
       case "sessions": {
-        const sessions = this.engine.getSessionManager().list();
-        this.transport.send(createResponse(req.id, { type: "sessions", data: sessions }));
+        if (this.chatManager) {
+          // Return the ChatSessionManager's live sessions
+          const sessions = [...(this.chatManager as any).sessions.entries()].map(
+            ([id, s]: [string, any]) => ({
+              sessionId: id,
+              busy: s.isBusy(),
+              queueDepth: s.queueDepth(),
+              lastActivityAt: s.lastActivityAt,
+            }),
+          );
+          this.transport.send(createResponse(req.id, { type: "sessions", data: sessions }));
+        } else if (engine) {
+          const sessions = engine.getSessionManager().list();
+          this.transport.send(createResponse(req.id, { type: "sessions", data: sessions }));
+        } else {
+          this.transport.send(createResponse(req.id, { type: "sessions", data: [] }));
+        }
         break;
       }
       case "config": {
-        const config = this.engine.getConfig();
+        if (!engine) {
+          this.transport.send(
+            createErrorResponse(req.id, ErrorCodes.InternalError, "No engine available for config query"),
+          );
+          return;
+        }
+        const config = engine.getConfig();
         this.transport.send(
           createResponse(req.id, {
             type: "config",
             data: {
               permissionMode: config.permissionMode ?? "default",
-              // TODO(T6): replace with this.engine.planMode once Engine exposes it.
-              planMode: false,
+              planMode: engine.planMode ?? false,
               preset: config.preset,
               model: config.llm.model,
               cwd: config.cwd,
@@ -310,9 +513,15 @@ export class AgentServer {
         break;
       }
       case "session_detail": {
+        if (!engine) {
+          this.transport.send(
+            createErrorResponse(req.id, ErrorCodes.InternalError, "No engine available for session_detail query"),
+          );
+          return;
+        }
         if (params.sessionId) {
           try {
-            const bundle = this.engine.getSessionManager().resume(params.sessionId);
+            const bundle = engine.getSessionManager().resume(params.sessionId);
             const data = {
               state: bundle.state,
               transcript: bundle.transcript.getEvents(),
@@ -335,9 +544,14 @@ export class AgentServer {
         break;
       }
       case "compact": {
-        // Force context compaction and return stats
+        if (!engine) {
+          this.transport.send(
+            createErrorResponse(req.id, ErrorCodes.InternalError, "No engine available for compact query"),
+          );
+          return;
+        }
         try {
-          const result = this.engine.forceCompact();
+          const result = engine.forceCompact();
           this.transport.send(
             createResponse(req.id, {
               type: "compact",
@@ -352,15 +566,17 @@ export class AgentServer {
         break;
       }
       case "models": {
-        const pool = this.engine.getModelPool();
+        if (!engine) {
+          this.transport.send(
+            createErrorResponse(req.id, ErrorCodes.InternalError, "No engine available for models query"),
+          );
+          return;
+        }
+        const pool = engine.getModelPool();
         const models: import("./types.js").ProtocolModelEntry[] = pool.list().map((m) => ({
           key: m.key,
           label: m.label ?? m.key,
           model: m.model,
-          // `protocol` is the engine-internal "which client speaks for this
-          // model" flag ("openai"/"anthropic"). ModelEntry.provider holds it
-          // legacy-style; we map it through here so the protocol surface
-          // doesn't leak the misleading name.
           protocol: m.provider,
           providerKey: m.providerKey,
           active: m.key === pool.getActiveKey(),
@@ -371,15 +587,15 @@ export class AgentServer {
         break;
       }
       case "providers": {
-        // Wraps config_get("providers") with two extras the ModelManager
-        // panel needs:
-        //   - modelCount: how many models[] entries reference this provider
-        //   - cachedModels/cachedAt: from <cacheDir>/<providerKey>.json
-        // Without these, the panel shows "0 模型 · 未拉取" even when the
-        // wizard has already pulled the model list.
+        if (!engine) {
+          this.transport.send(
+            createErrorResponse(req.id, ErrorCodes.InternalError, "No engine available for providers query"),
+          );
+          return;
+        }
         try {
-          const providersRaw = this.engine.readSetting("providers") as unknown;
-          const modelsRaw = this.engine.readSetting("models") as unknown;
+          const providersRaw = engine.readSetting("providers") as unknown;
+          const modelsRaw = engine.readSetting("models") as unknown;
           const providerList = Array.isArray(providersRaw)
             ? (providersRaw as Array<Record<string, unknown>>)
             : [];
@@ -414,19 +630,21 @@ export class AgentServer {
         break;
       }
       case "arena_status": {
-        // Returns what Arena would do if invoked right now: which
-        // participants it would default to, against which endpoint,
-        // and whether each one looks compatible.
         const status = getArenaStatus();
         this.transport.send(createResponse(req.id, { type: "arena_status", data: status }));
         break;
       }
       case "config_set": {
-        // Update a settings key
+        if (!engine) {
+          this.transport.send(
+            createErrorResponse(req.id, ErrorCodes.InternalError, "No engine available for config_set"),
+          );
+          return;
+        }
         try {
           const { key, value } = params;
           if (!key) throw new Error("key is required for config_set");
-          this.engine.updateConfig(key, value);
+          engine.updateConfig(key, value);
           this.transport.send(createResponse(req.id, { type: "config_set", data: { key, value } }));
         } catch (err) {
           this.transport.send(
@@ -436,10 +654,16 @@ export class AgentServer {
         break;
       }
       case "config_get": {
+        if (!engine) {
+          this.transport.send(
+            createErrorResponse(req.id, ErrorCodes.InternalError, "No engine available for config_get"),
+          );
+          return;
+        }
         try {
           const { key } = params;
           if (!key) throw new Error("key is required for config_get");
-          const value = this.engine.readSetting(key);
+          const value = engine.readSetting(key);
           this.transport.send(createResponse(req.id, { type: "config_get", data: { key, value } }));
         } catch (err) {
           this.transport.send(
@@ -449,13 +673,19 @@ export class AgentServer {
         break;
       }
       case "permission_set": {
+        if (!engine) {
+          this.transport.send(
+            createErrorResponse(req.id, ErrorCodes.InternalError, "No engine available for permission_set"),
+          );
+          return;
+        }
         try {
           const value = params.value as string | undefined;
           const valid = ["default", "acceptEdits", "dontAsk", "bypassPermissions", "auto", "plan"];
           if (!value || !valid.includes(value)) {
             throw new Error(`invalid permission mode: ${value}`);
           }
-          this.engine.setPermissionMode(value as NonNullable<EngineConfig["permissionMode"]>);
+          engine.setPermissionMode(value as NonNullable<EngineConfig["permissionMode"]>);
           this.transport.send(
             createResponse(req.id, {
               type: "permission_set",
@@ -470,6 +700,12 @@ export class AgentServer {
         break;
       }
       case "provider_add": {
+        if (!engine) {
+          this.transport.send(
+            createErrorResponse(req.id, ErrorCodes.InternalError, "No engine available for provider_add"),
+          );
+          return;
+        }
         try {
           const cfg = params.provider as Record<string, unknown> | undefined;
           if (
@@ -480,9 +716,9 @@ export class AgentServer {
           ) {
             throw new Error("provider_add: requires {key, kind, baseUrl, ...}");
           }
-          const current = (this.engine.readSetting("providers") as unknown[] | undefined) ?? [];
+          const current = (engine.readSetting("providers") as unknown[] | undefined) ?? [];
           const next = [...current, cfg];
-          this.engine.updateConfig("providers", next);
+          engine.updateConfig("providers", next);
           this.transport.send(
             createResponse(req.id, { type: "provider_add", data: { ok: true, key: cfg.key } }),
           );
@@ -494,11 +730,17 @@ export class AgentServer {
         break;
       }
       case "provider_refresh": {
+        if (!engine) {
+          this.transport.send(
+            createErrorResponse(req.id, ErrorCodes.InternalError, "No engine available for provider_refresh"),
+          );
+          return;
+        }
         try {
           const key = params.key;
           if (!key) throw new Error("provider_refresh: key required");
           const providers =
-            (this.engine.readSetting("providers") as Array<Record<string, unknown>> | undefined) ??
+            (engine.readSetting("providers") as Array<Record<string, unknown>> | undefined) ??
             [];
           const p = providers.find((x) => x.key === key);
           if (!p) throw new Error(`provider not found: ${key}`);
@@ -527,20 +769,26 @@ export class AgentServer {
         break;
       }
       case "provider_delete": {
+        if (!engine) {
+          this.transport.send(
+            createErrorResponse(req.id, ErrorCodes.InternalError, "No engine available for provider_delete"),
+          );
+          return;
+        }
         try {
           const key = params.key;
           if (!key) throw new Error("provider_delete: key required");
           const models =
-            (this.engine.readSetting("models") as Array<Record<string, unknown>> | undefined) ?? [];
+            (engine.readSetting("models") as Array<Record<string, unknown>> | undefined) ?? [];
           const refs = models.filter((m) => m.providerKey === key).map((m) => m.key as string);
           if (refs.length > 0) {
             throw new Error(`provider ${key} referenced by models: ${refs.join(", ")}`);
           }
           const providers =
-            (this.engine.readSetting("providers") as Array<Record<string, unknown>> | undefined) ??
+            (engine.readSetting("providers") as Array<Record<string, unknown>> | undefined) ??
             [];
           const next = providers.filter((p) => p.key !== key);
-          this.engine.updateConfig("providers", next);
+          engine.updateConfig("providers", next);
           this.transport.send(
             createResponse(req.id, { type: "provider_delete", data: { ok: true } }),
           );
@@ -552,14 +800,20 @@ export class AgentServer {
         break;
       }
       case "model_add": {
+        if (!engine) {
+          this.transport.send(
+            createErrorResponse(req.id, ErrorCodes.InternalError, "No engine available for model_add"),
+          );
+          return;
+        }
         try {
           const entry = params.model as Record<string, unknown> | undefined;
           if (!entry || typeof entry.key !== "string" || typeof entry.model !== "string") {
             throw new Error("model_add: requires {key, model, providerKey}");
           }
-          const current = (this.engine.readSetting("models") as unknown[] | undefined) ?? [];
+          const current = (engine.readSetting("models") as unknown[] | undefined) ?? [];
           const next = [...current, entry];
-          this.engine.updateConfig("models", next);
+          engine.updateConfig("models", next);
           this.transport.send(
             createResponse(req.id, { type: "model_add", data: { ok: true, key: entry.key } }),
           );
@@ -571,13 +825,19 @@ export class AgentServer {
         break;
       }
       case "model_delete": {
+        if (!engine) {
+          this.transport.send(
+            createErrorResponse(req.id, ErrorCodes.InternalError, "No engine available for model_delete"),
+          );
+          return;
+        }
         try {
           const key = params.key;
           if (!key) throw new Error("model_delete: key required");
           const current =
-            (this.engine.readSetting("models") as Array<Record<string, unknown>> | undefined) ?? [];
+            (engine.readSetting("models") as Array<Record<string, unknown>> | undefined) ?? [];
           const next = current.filter((m) => m.key !== key);
-          this.engine.updateConfig("models", next);
+          engine.updateConfig("models", next);
           this.transport.send(
             createResponse(req.id, { type: "model_delete", data: { ok: true } }),
           );
@@ -609,8 +869,31 @@ export class AgentServer {
       );
       return;
     }
+    // In the chatManager path, inject into the session's engine
+    if (this.chatManager) {
+      const s = this.chatManager.get(params.sessionId);
+      if (!s) {
+        this.transport.send(
+          createErrorResponse(
+            req.id,
+            ErrorCodes.SessionClosed,
+            `No such session: ${params.sessionId}`,
+          ),
+        );
+        return;
+      }
+      try {
+        s.engine.injectContext(params.sessionId, params.content);
+        this.transport.send(createResponse(req.id, { ok: true }));
+      } catch (err) {
+        this.transport.send(
+          createErrorResponse(req.id, ErrorCodes.InternalError, (err as Error).message),
+        );
+      }
+      return;
+    }
     try {
-      this.engine.injectContext(params.sessionId, params.content);
+      this.legacyEngine!.injectContext(params.sessionId, params.content);
       this.transport.send(createResponse(req.id, { ok: true }));
     } catch (err) {
       this.transport.send(
@@ -622,8 +905,7 @@ export class AgentServer {
   // ─── Client Communication ───────────────────────────────────────
 
   /**
-   * Ask the client to approve a tool operation.
-   * Sends a notification, returns a promise that resolves when client responds.
+   * Ask the client to approve a tool operation (legacy single-engine path).
    */
   private requestApprovalFromClient(request: ApprovalRequest): Promise<ApprovalResult> {
     return new Promise((resolve) => {
@@ -644,10 +926,7 @@ export class AgentServer {
   }
 
   /**
-   * Ask the client to answer a question from the agent.
-   * Reuses the approval flow with a synthetic request. Optional `opts`
-   * carry multiple-choice options / header / multiSelect hints that the
-   * client UI may use to render a picker instead of a text input.
+   * Ask the client to answer a question from the agent (legacy single-engine path).
    */
   private requestAskUserFromClient(
     question: string,
@@ -673,8 +952,6 @@ export class AgentServer {
       }, AgentServer.APPROVAL_TIMEOUT_MS);
       this.approvalTimers.set(requestId, timer);
 
-      // Pass options through the synthetic request's `args` — clients that
-      // don't know about them ignore the extra fields and still see `question`.
       const args: Record<string, unknown> = { question };
       if (opts?.header !== undefined) args.header = opts.header;
       if (opts?.options !== undefined) args.options = opts.options;
@@ -696,23 +973,34 @@ export class AgentServer {
     this.transport.send(createNotification(method, params));
   }
 
+  /**
+   * Get any available engine — used for global query ops when chatManager is
+   * present but no legacyEngine was supplied. Borrows the first live session.
+   */
+  private anyEngine(): Engine | null {
+    if (!this.chatManager) return null;
+    // Access private `sessions` map — acceptable for same-package access.
+    const sessions: Map<string, any> = (this.chatManager as any).sessions;
+    const first = sessions.values().next().value;
+    return first ? (first.engine as Engine) : null;
+  }
+
   // ─── Lifecycle ──────────────────────────────────────────────────
 
   close(): void {
-    // Abort an in-flight engine.run so the awaited promise in handleRun
-    // settles and the finally block clears `this.running`. Without this,
-    // closing a server during an active run leaves the engine churning
-    // until natural completion, defeating the point of close().
+    if (this.chatManager) {
+      this.chatManager.closeAll();
+    }
+
+    // Legacy path cleanup
     if (this.abortController) {
       try {
         this.abortController.abort("server closing");
       } catch {
-        // swallow — best-effort abort
+        // swallow
       }
     }
 
-    // Reject pending approvals so any sub-agent or tool waiting on a
-    // user decision unblocks instead of hanging forever.
     for (const [, resolve] of this.pendingApprovals) {
       resolve({ approved: false, reason: "server closing" });
     }

--- a/packages/core/src/protocol/server.ts
+++ b/packages/core/src/protocol/server.ts
@@ -27,7 +27,6 @@ import {
 } from "./types.js";
 import type { Engine, EngineConfig } from "../engine/engine.js";
 import type { ApprovalRequest, ApprovalResult, StreamEvent } from "../types.js";
-import { setRuntimeBypass, isRuntimeBypass } from "../tool-system/permission.js";
 import { setInteractiveApprovalFn } from "../tool-system/permission.js";
 import { getArenaStatus } from "../tool-system/builtin/arena.js";
 import { taskManager } from "../tool-system/builtin/task.js";
@@ -225,9 +224,8 @@ export class AgentServer {
       // TODO(T6): once Engine exposes setPlanMode(), call this.engine.setPlanMode(params.planMode).
       // For now, plan-mode toggling via Configure is a no-op until T6 wires Engine.planMode.
     }
-    if (params.bypassPermissions !== undefined) {
-      setRuntimeBypass(params.bypassPermissions);
-    }
+    // TODO(T10): wire params.bypassPermissions through Engine.permissionMode once
+    // handleConfigure is rewritten in T10.
     if (params.reloadModels) {
       // Pick up newly persisted providers[]/models[] (e.g. from /login)
       // before any model-key switch below tries to find them.

--- a/packages/core/src/protocol/server.ts
+++ b/packages/core/src/protocol/server.ts
@@ -27,7 +27,6 @@ import {
 } from "./types.js";
 import type { Engine, EngineConfig } from "../engine/engine.js";
 import type { ApprovalRequest, ApprovalResult, StreamEvent } from "../types.js";
-import { setInPlanMode, isInPlanMode } from "../tool-system/builtin/plan.js";
 import { setRuntimeBypass, isRuntimeBypass } from "../tool-system/permission.js";
 import { setInteractiveApprovalFn } from "../tool-system/permission.js";
 import { getArenaStatus } from "../tool-system/builtin/arena.js";
@@ -223,7 +222,8 @@ export class AgentServer {
     const params = (req.params ?? {}) as unknown as ConfigureParams;
 
     if (params.planMode !== undefined) {
-      setInPlanMode(params.planMode);
+      // TODO(T6): once Engine exposes setPlanMode(), call this.engine.setPlanMode(params.planMode).
+      // For now, plan-mode toggling via Configure is a no-op until T6 wires Engine.planMode.
     }
     if (params.bypassPermissions !== undefined) {
       setRuntimeBypass(params.bypassPermissions);
@@ -291,7 +291,8 @@ export class AgentServer {
             type: "config",
             data: {
               permissionMode: config.permissionMode ?? "default",
-              planMode: isInPlanMode(),
+              // TODO(T6): replace with this.engine.planMode once Engine exposes it.
+              planMode: false,
               preset: config.preset,
               model: config.llm.model,
               cwd: config.cwd,

--- a/packages/core/src/protocol/server.ts
+++ b/packages/core/src/protocol/server.ts
@@ -382,8 +382,8 @@ export class AgentServer {
     const params = (req.params ?? {}) as unknown as ConfigureParams;
 
     // If a sessionId is present, mutate that specific session's engine
-    if (this.chatManager && typeof (params as any).sessionId === "string") {
-      const sid = (params as any).sessionId as string;
+    if (this.chatManager && typeof params.sessionId === "string") {
+      const sid = params.sessionId;
       const s = this.chatManager.get(sid);
       if (!s) {
         this.transport.send(

--- a/packages/core/src/protocol/types.ts
+++ b/packages/core/src/protocol/types.ts
@@ -59,18 +59,20 @@ export const ErrorCodes = {
   InvalidParams: -32602,
   InternalError: -32603,
   // Custom codes
-  EngineNotReady: -32001,
+  Overloaded: -32001,
   SessionNotFound: -32002,
-  AlreadyRunning: -32003,
-  NotRunning: -32004,
+  SessionClosed: -32004,
 } as const;
 
 // ─── Client → Server Requests ───────────────────────────────────────
 
 /** Start an agent run with a user task. */
 export interface RunParams {
+  sessionId: string;          // required, client-minted
   task: string;
-  sessionId?: string;
+  cwd?: string;
+  permissionMode?: PermissionMode;
+  planMode?: boolean;
 }
 
 export interface RunResult {
@@ -83,13 +85,20 @@ export interface RunResult {
 
 /** Respond to an approval request from the server. */
 export interface ApproveParams {
+  sessionId: string;
   requestId: string;
   decision: ApprovalResult;
 }
 
-/** Cancel a running agent. */
+/** Cancel a running agent turn. */
 export interface CancelParams {
+  sessionId: string;
   reason?: string;
+}
+
+/** Close (destroy) a session. */
+export interface CloseSessionParams {
+  sessionId: string;
 }
 
 /** Inject context into a session transcript. */
@@ -213,8 +222,14 @@ export interface ConfigResult {
 
 // ─── Server → Client Notifications ─────────────────────────────────
 
-/** Stream event forwarded from the engine. */
+/** Stream event forwarded from the engine (legacy, no sessionId). */
 export interface StreamEventNotification {
+  event: StreamEvent;
+}
+
+/** Multi-session stream event envelope — carries the originating sessionId. */
+export interface AgentStreamEventNotification {
+  sessionId: string;
   event: StreamEvent;
 }
 
@@ -241,6 +256,8 @@ export const Methods = {
   Query: "agent/query",
   /** Inject context into transcript without triggering LLM. */
   Inject: "agent/inject",
+  /** Close (destroy) a session. */
+  CloseSession: "agent/closeSession",
 
   // Server → Client (notifications, no id)
   StreamEvent: "agent/streamEvent",

--- a/packages/core/src/protocol/types.ts
+++ b/packages/core/src/protocol/types.ts
@@ -109,6 +109,8 @@ export interface InjectParams {
 
 /** Update runtime configuration. */
 export interface ConfigureParams {
+  /** When present, configure that specific chat session. Otherwise worker-global. */
+  sessionId?: string;
   permissionMode?: PermissionMode;
   planMode?: boolean;
   bypassPermissions?: boolean;

--- a/packages/core/src/tool-system/builtin/agent.ts
+++ b/packages/core/src/tool-system/builtin/agent.ts
@@ -9,7 +9,6 @@
 
 import type { ToolDefinition, StreamCallback } from "../../types.js";
 import type { ToolContext, SubAgentSpawner } from "../context.js";
-import { isInPlanMode, resetPlanMode, restorePlanMode } from "./plan.js";
 import { asyncAgentRegistry } from "./agent-registry.js";
 import { createTranscriptTranslator } from "./agent-transcript-translator.js";
 import { notificationQueue } from "./agent-notifications.js";
@@ -99,17 +98,13 @@ async function runSubAgent(
 
   startEndSink?.({ type: "agent_start", agentId, name, description });
 
-  const parentWasInPlanMode = isInPlanMode();
-  if (parentWasInPlanMode) resetPlanMode();
-
-  try {
-    const text = await spawner.spawn({ ...opts, streamOverride });
-    const finalText = text || `Agent completed but produced no text output.`;
-    startEndSink?.({ type: "agent_end", agentId, name, description, text: finalText });
-    return finalText;
-  } finally {
-    if (parentWasInPlanMode) restorePlanMode();
-  }
+  // `resetPlanMode` / `restorePlanMode` are no longer needed: the child
+  // Engine receives its own planMode at construction time, and the parent
+  // Engine's planMode is unaffected.
+  const text = await spawner.spawn({ ...opts, streamOverride });
+  const finalText = text || `Agent completed but produced no text output.`;
+  startEndSink?.({ type: "agent_end", agentId, name, description, text: finalText });
+  return finalText;
 }
 
 export async function agentTool(

--- a/packages/core/src/tool-system/builtin/agent.ts
+++ b/packages/core/src/tool-system/builtin/agent.ts
@@ -98,9 +98,10 @@ async function runSubAgent(
 
   startEndSink?.({ type: "agent_start", agentId, name, description });
 
-  // `resetPlanMode` / `restorePlanMode` are no longer needed: the child
-  // Engine receives its own planMode at construction time, and the parent
-  // Engine's planMode is unaffected.
+  // `resetPlanMode` / `restorePlanMode` operated on a module-level singleton
+  // that no longer exists. The child Engine is a fresh instance; plan-mode
+  // isolation between parent and child is enforced via separate Engine
+  // instances (finalized in T6).
   const text = await spawner.spawn({ ...opts, streamOverride });
   const finalText = text || `Agent completed but produced no text output.`;
   startEndSink?.({ type: "agent_end", agentId, name, description, text: finalText });

--- a/packages/core/src/tool-system/builtin/plan.ts
+++ b/packages/core/src/tool-system/builtin/plan.ts
@@ -43,11 +43,11 @@ export async function enterPlanModeTool(
   _args: Record<string, unknown>,
   ctx?: ToolContext,
 ): Promise<string> {
-  if (ctx?.planMode) {
+  if (ctx?.engine?.planMode) {
     return "Already in plan mode. Output your plan as text, then call ExitPlanMode.";
   }
 
-  ctx?.engine?.setPlanMode(true);
+  ctx?.engine.setPlanMode(true);
 
   return [
     "Entered plan mode.",
@@ -65,11 +65,11 @@ export async function exitPlanModeTool(
   _args: Record<string, unknown>,
   ctx?: ToolContext,
 ): Promise<string> {
-  if (!ctx?.planMode) {
+  if (!ctx?.engine?.planMode) {
     return "Not currently in plan mode.";
   }
 
-  ctx?.engine?.setPlanMode(false);
+  ctx?.engine.setPlanMode(false);
 
   return "Exited plan mode. You can now write and edit files to implement the plan.";
 }

--- a/packages/core/src/tool-system/builtin/plan.ts
+++ b/packages/core/src/tool-system/builtin/plan.ts
@@ -47,8 +47,7 @@ export async function enterPlanModeTool(
     return "Already in plan mode. Output your plan as text, then call ExitPlanMode.";
   }
 
-  // TODO(T7): once Engine populates ToolContext.engine, call ctx.engine.setPlanMode(true).
-  // For now, plan-mode entry is a no-op from the tool side — engine sets it via constructor.
+  ctx?.engine?.setPlanMode(true);
 
   return [
     "Entered plan mode.",
@@ -70,8 +69,7 @@ export async function exitPlanModeTool(
     return "Not currently in plan mode.";
   }
 
-  // TODO(T7): once Engine populates ToolContext.engine, call ctx.engine.setPlanMode(false).
-  // For now, plan-mode exit is a no-op from the tool side — engine manages its own state.
+  ctx?.engine?.setPlanMode(false);
 
   return "Exited plan mode. You can now write and edit files to implement the plan.";
 }

--- a/packages/core/src/tool-system/builtin/plan.ts
+++ b/packages/core/src/tool-system/builtin/plan.ts
@@ -9,6 +9,7 @@
  */
 
 import type { ToolDefinition } from "../../types.js";
+import type { ToolContext } from "../context.js";
 
 export const enterPlanModeToolDef: ToolDefinition = {
   name: "EnterPlanMode",
@@ -36,34 +37,18 @@ export const exitPlanModeToolDef: ToolDefinition = {
   },
 };
 
-// ─── Plan mode state ──────────────────────────────────────────
-
-let _inPlanMode = false;
-
-export function isInPlanMode(): boolean {
-  return _inPlanMode;
-}
-
-export function setInPlanMode(value: boolean): void {
-  _inPlanMode = value;
-}
-
-export function resetPlanMode(): void {
-  _inPlanMode = false;
-}
-
-export function restorePlanMode(): void {
-  _inPlanMode = true;
-}
-
 // ─── Tool implementations ─────────────────────────────────────
 
-export async function enterPlanModeTool(_args: Record<string, unknown>): Promise<string> {
-  if (_inPlanMode) {
+export async function enterPlanModeTool(
+  _args: Record<string, unknown>,
+  ctx?: ToolContext,
+): Promise<string> {
+  if (ctx?.planMode) {
     return "Already in plan mode. Output your plan as text, then call ExitPlanMode.";
   }
 
-  _inPlanMode = true;
+  // TODO(T7): once Engine populates ToolContext.engine, call ctx.engine.setPlanMode(true).
+  // For now, plan-mode entry is a no-op from the tool side — engine sets it via constructor.
 
   return [
     "Entered plan mode.",
@@ -77,11 +62,16 @@ export async function enterPlanModeTool(_args: Record<string, unknown>): Promise
   ].join("\n");
 }
 
-export async function exitPlanModeTool(_args: Record<string, unknown>): Promise<string> {
-  if (!_inPlanMode) {
+export async function exitPlanModeTool(
+  _args: Record<string, unknown>,
+  ctx?: ToolContext,
+): Promise<string> {
+  if (!ctx?.planMode) {
     return "Not currently in plan mode.";
   }
 
-  _inPlanMode = false;
+  // TODO(T7): once Engine populates ToolContext.engine, call ctx.engine.setPlanMode(false).
+  // For now, plan-mode exit is a no-op from the tool side — engine manages its own state.
+
   return "Exited plan mode. You can now write and edit files to implement the plan.";
 }

--- a/packages/core/src/tool-system/context.ts
+++ b/packages/core/src/tool-system/context.ts
@@ -124,6 +124,9 @@ export interface ToolContext {
    * standalone tests; tools must tolerate absence.
    */
   hooks?: HookRegistry;
+  /** Whether the owning Engine is currently in plan mode. Replaces the
+   *  removed module-level `isInPlanMode()` singleton. */
+  planMode: boolean;
 }
 
 /**

--- a/packages/core/src/tool-system/context.ts
+++ b/packages/core/src/tool-system/context.ts
@@ -18,6 +18,7 @@ import type { ToolRegistry } from "./registry.js";
 import type { AgentPresetName } from "../preset/index.js";
 import type { SandboxBackend } from "./sandbox/index.js";
 import type { HookRegistry } from "../hooks/registry.js";
+import type { Engine } from "../engine/engine.js";
 
 /** One choice in a multiple-choice AskUserQuestion. */
 export interface AskUserChoice {
@@ -127,6 +128,9 @@ export interface ToolContext {
   /** Whether the owning Engine is currently in plan mode. Replaces the
    *  removed module-level `isInPlanMode()` singleton. */
   planMode: boolean;
+  /** The Engine that built this context. Lets tools call back into the engine
+   *  (e.g. ctx.engine.setPlanMode(true/false)) without a module-level singleton. */
+  engine: Engine;
 }
 
 /**

--- a/packages/core/src/tool-system/executor.ts
+++ b/packages/core/src/tool-system/executor.ts
@@ -9,7 +9,6 @@ import { PermissionClassifier } from "./permission.js";
 import { PermissionDeniedError } from "../exceptions.js";
 import { logger as rootLogger, getCurrentSid } from "../logging/logger.js";
 import { recordToolCall, recordToolResult } from "../logging/session-recorder.js";
-import { isInPlanMode } from "./builtin/plan.js";
 import { validateToolArgs } from "./validation.js";
 import type { ToolContext } from "./context.js";
 import type { InvestigationGuard } from "./investigation-guard.js";
@@ -79,7 +78,7 @@ export class ToolExecutor {
     // without mutating the caller's object.
     let call: ToolCall = callIn;
     // 0. Plan mode: only allow read-only tools — no file writes at all
-    if (isInPlanMode()) {
+    if (this.toolCtx?.planMode) {
       const allowedInPlan = new Set([
         "EnterPlanMode",
         "ExitPlanMode",

--- a/packages/core/src/tool-system/permission.ts
+++ b/packages/core/src/tool-system/permission.ts
@@ -454,18 +454,6 @@ export class DenialTracker {
   }
 }
 
-// ─── Runtime permission override ─────────────────────────────
-// Allows the UI to toggle bypass mode without recreating the classifier.
-let _runtimeBypass = false;
-
-export function setRuntimeBypass(enabled: boolean): void {
-  _runtimeBypass = enabled;
-}
-
-export function isRuntimeBypass(): boolean {
-  return _runtimeBypass;
-}
-
 export class PermissionClassifier {
   private denialTracker = new DenialTracker();
   /**
@@ -501,8 +489,8 @@ export class PermissionClassifier {
   }
 
   classify(toolName: string, args: Record<string, unknown>): PermissionDecision {
-    // Runtime bypass overrides everything
-    if (_runtimeBypass) return "allow";
+    // bypassPermissions mode overrides everything
+    if (this.defaultMode === "bypassPermissions") return "allow";
 
     // Check explicit rules (ordered by specificity)
     for (const rule of this.rules) {
@@ -514,7 +502,6 @@ export class PermissionClassifier {
     // YOLO classifier for Bash commands
     if (toolName === "Bash") {
       const level = classifyBashCommand(String(args.command ?? ""));
-      if (this.defaultMode === "bypassPermissions") return "allow";
       if (level === "dangerous") return "ask";
       if (level === "safe-read") return "allow";
       if (
@@ -528,8 +515,6 @@ export class PermissionClassifier {
 
     // Fall back to default mode
     switch (this.defaultMode) {
-      case "bypassPermissions":
-        return "allow";
       case "dontAsk":
         return "deny";
       case "acceptEdits":

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -78,7 +78,9 @@ ipcRenderer.on(RPC_TO_RENDERER, (_ipcEvent, msg: IncomingMessage) => {
     if (pending) {
       _pending.delete(msg.id as number);
       if ("error" in msg && msg.error) {
-        pending.reject(new Error(msg.error.message));
+        const err = new Error(msg.error.message);
+        (err as { code?: number }).code = msg.error.code;
+        pending.reject(err);
       } else {
         pending.resolve((msg as RpcResponse).result);
       }

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -1,7 +1,18 @@
 /**
- * Preload — exposes a minimal IPC surface to the renderer via
+ * Preload — exposes a minimal, typed IPC surface to the renderer via
  * contextBridge. The renderer never sees ipcRenderer directly so
  * contextIsolation stays meaningful.
+ *
+ * All requests to the main process are JSON-RPC 2.0 messages sent via
+ * `code-shell:rpc:to-main`. Responses and notifications from the main
+ * process arrive via `code-shell:rpc:to-renderer`.
+ *
+ * Stream events are delivered as { sessionId, event } envelopes so the
+ * renderer can route them to the correct session bucket.
+ *
+ * NOTE: sessionId is required on run/cancel/approve/closeSession. This
+ * is intentional — T14 will update App.tsx to supply it. Until T14
+ * lands, App.tsx callers will have a typecheck error.
  */
 
 import { contextBridge, ipcRenderer } from "electron";
@@ -9,19 +20,138 @@ import { contextBridge, ipcRenderer } from "electron";
 const RPC_FROM_RENDERER = "code-shell:rpc:to-main";
 const RPC_TO_RENDERER = "code-shell:rpc:to-renderer";
 
-type RpcMessage = unknown;
-type Listener = (msg: RpcMessage) => void;
+// ─── Internal types (preload-only) ──────────────────────────────────
 
-contextBridge.exposeInMainWorld("codeShell", {
-  sendRpc(msg: RpcMessage): void {
-    ipcRenderer.send(RPC_FROM_RENDERER, msg);
+interface RpcRequest {
+  jsonrpc: "2.0";
+  id: number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface RpcResponse {
+  jsonrpc: "2.0";
+  id: number;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+interface RpcNotification {
+  jsonrpc: "2.0";
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+type IncomingMessage = RpcResponse | RpcNotification;
+
+// ─── Pending RPC call registry ───────────────────────────────────────
+
+let _nextId = 1;
+const _pending = new Map<
+  number,
+  { resolve: (v: unknown) => void; reject: (e: Error) => void }
+>();
+
+function rpc(method: string, params?: Record<string, unknown>): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const id = _nextId++;
+    _pending.set(id, { resolve, reject });
+    const req: RpcRequest = { jsonrpc: "2.0", id, method, params };
+    ipcRenderer.send(RPC_FROM_RENDERER, req);
+  });
+}
+
+// ─── Listener sets ───────────────────────────────────────────────────
+
+type StreamEnvelope = { sessionId: string; event: unknown };
+type ApprovalEnvelope = { sessionId: string; requestId: string; request: unknown };
+
+const streamListeners = new Set<(env: StreamEnvelope) => void>();
+const approvalListeners = new Set<(env: ApprovalEnvelope) => void>();
+
+// ─── Incoming message router ─────────────────────────────────────────
+
+ipcRenderer.on(RPC_TO_RENDERER, (_ipcEvent, msg: IncomingMessage) => {
+  // Response to a pending call
+  if ("id" in msg && msg.id != null) {
+    const pending = _pending.get(msg.id as number);
+    if (pending) {
+      _pending.delete(msg.id as number);
+      if ("error" in msg && msg.error) {
+        pending.reject(new Error(msg.error.message));
+      } else {
+        pending.resolve((msg as RpcResponse).result);
+      }
+    }
+    return;
+  }
+
+  // Notification (no id)
+  const notification = msg as RpcNotification;
+  const { method, params } = notification;
+
+  if (method === "agent/streamEvent") {
+    const sessionId = params?.sessionId as string;
+    const event = params?.event;
+    streamListeners.forEach((cb) => cb({ sessionId, event }));
+  } else if (method === "agent/approvalRequest") {
+    const sessionId = params?.sessionId as string;
+    const requestId = params?.requestId as string;
+    const request = params?.request;
+    approvalListeners.forEach((cb) => cb({ sessionId, requestId, request }));
+  }
+});
+
+// ─── Exposed bridge ──────────────────────────────────────────────────
+
+contextBridge.exposeInMainWorld("codeshell", {
+  /**
+   * Start a new agent run inside the given session.
+   * sessionId is REQUIRED — create one with crypto.randomUUID() before calling.
+   */
+  run: (task: string, opts: { sessionId: string; cwd?: string; permissionMode?: string }) =>
+    rpc("agent/run", { task, ...opts }),
+
+  /** Cancel the running turn in the given session. */
+  cancel: (sessionId: string) => rpc("agent/cancel", { sessionId }),
+
+  /**
+   * Respond to an approval request.
+   * decision shape mirrors ApprovalResult from @cjhyy/code-shell-core.
+   */
+  approve: (
+    sessionId: string,
+    requestId: string,
+    decision: {
+      approved: boolean;
+      permanent?: boolean;
+      always?: boolean;
+      scope?: "once" | "session" | "project";
+      reason?: string;
+      answer?: string;
+    },
+  ) => rpc("agent/approve", { sessionId, requestId, decision }),
+
+  /** Destroy (close) a session and free its resources. */
+  closeSession: (sessionId: string) => rpc("agent/closeSession", { sessionId }),
+
+  /** Register a callback that fires for every stream event envelope. */
+  onStreamEvent: (cb: (env: StreamEnvelope) => void): void => {
+    streamListeners.add(cb);
   },
-  onRpc(listener: Listener): (event: unknown, msg: RpcMessage) => void {
-    const wrapped = (_event: unknown, msg: RpcMessage): void => listener(msg);
-    ipcRenderer.on(RPC_TO_RENDERER, wrapped);
-    return wrapped;
+
+  /** Unregister a stream event callback previously registered with onStreamEvent. */
+  offStreamEvent: (cb: (env: StreamEnvelope) => void): void => {
+    streamListeners.delete(cb);
   },
-  removeRpcListener(wrapped: (event: unknown, msg: RpcMessage) => void): void {
-    ipcRenderer.removeListener(RPC_TO_RENDERER, wrapped);
+
+  /** Register a callback that fires when the server requests tool approval. */
+  onApprovalRequest: (cb: (env: ApprovalEnvelope) => void): void => {
+    approvalListeners.add(cb);
+  },
+
+  /** Unregister an approval request callback. */
+  offApprovalRequest: (cb: (env: ApprovalEnvelope) => void): void => {
+    approvalListeners.delete(cb);
   },
 });

--- a/packages/desktop/src/preload/types.d.ts
+++ b/packages/desktop/src/preload/types.d.ts
@@ -1,9 +1,83 @@
+/**
+ * Type declarations for the preload bridge exposed as `window.codeshell`.
+ *
+ * StreamEvent is kept as `unknown` here to avoid importing Node/core types
+ * into the renderer type graph. App.tsx narrows it with type guards after
+ * receiving the envelope.
+ *
+ * ApprovalResult decision shape mirrors ApprovalResult from
+ * @cjhyy/code-shell-core — kept inline to avoid renderer/Node coupling.
+ */
+
+/** Envelope delivered to onStreamEvent callbacks. */
+export interface StreamEnvelope {
+  sessionId: string;
+  /** The raw StreamEvent from the engine. Use type guards to narrow. */
+  event: unknown;
+}
+
+/** Envelope delivered to onApprovalRequest callbacks. */
+export interface ApprovalEnvelope {
+  sessionId: string;
+  requestId: string;
+  /** The raw ApprovalRequest from the engine. */
+  request: unknown;
+}
+
+/** Decision payload sent back via approve(). */
+export interface ApprovalDecision {
+  approved: boolean;
+  permanent?: boolean;
+  always?: boolean;
+  scope?: "once" | "session" | "project";
+  reason?: string;
+  /** Free-text answer for AskUserQuestion approvals. */
+  answer?: string;
+}
+
 declare global {
   interface Window {
-    codeShell: {
-      sendRpc(msg: unknown): void;
-      onRpc(listener: (msg: unknown) => void): (event: unknown, msg: unknown) => void;
-      removeRpcListener(wrapped: (event: unknown, msg: unknown) => void): void;
+    codeshell: {
+      /**
+       * Start an agent run. sessionId must be a pre-allocated UUID.
+       * T14 NOTE: sessionId is required — callers must supply it.
+       */
+      run(
+        task: string,
+        opts: { sessionId: string; cwd?: string; permissionMode?: string },
+      ): Promise<unknown>;
+
+      /** Cancel the running turn for the given session. */
+      cancel(sessionId: string): Promise<unknown>;
+
+      /** Respond to a tool approval request. */
+      approve(
+        sessionId: string,
+        requestId: string,
+        decision: ApprovalDecision,
+      ): Promise<unknown>;
+
+      /** Destroy the session and free its resources on the main process. */
+      closeSession(sessionId: string): Promise<unknown>;
+
+      /**
+       * Register a callback to receive stream event envelopes.
+       * The envelope carries { sessionId, event } so the renderer can
+       * route events to the correct session's state bucket.
+       */
+      onStreamEvent(cb: (env: StreamEnvelope) => void): void;
+
+      /** Unregister a stream event callback. */
+      offStreamEvent(cb: (env: StreamEnvelope) => void): void;
+
+      /**
+       * Register a callback to receive approval request envelopes.
+       * The envelope carries { sessionId, requestId, request }.
+       */
+      onApprovalRequest(cb: (env: ApprovalEnvelope) => void): void;
+
+      /** Unregister an approval request callback. */
+      offApprovalRequest(cb: (env: ApprovalEnvelope) => void): void;
     };
   }
 }

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -1,55 +1,333 @@
-import React from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import type { StreamEnvelope } from "../preload/types.js";
 
-/**
- * Placeholder renderer.
- *
- * Renderer is a "thin client" by design: it MUST NOT import any
- * codeshell source. All Engine / AgentServer logic lives in the main
- * process. The renderer will only talk to main through the
- * `window.codeShell.*` surface exposed by preload (see
- * src/preload/index.ts).
- *
- * That bridge is not wired yet — it depends on:
- *   1. The monorepo split landing (so `@cjhyy/code-shell-core` is a real
- *      package main can import without dragging Node modules into the
- *      renderer bundle).
- *   2. main.ts running `AgentServer(engine, ipcTransport)` and exposing
- *      run/cancel/approve over `ipcMain.handle`.
- *   3. preload.ts re-exposing those as named methods on
- *      `window.codeShell`.
- *
- * Until then the renderer shows this placeholder. The Electron window
- * opening at all is enough to prove the dev orchestrator (vite +
- * esbuild + electron) works end-to-end.
- */
-export function App(): React.ReactElement {
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface SessionState {
+  sessionId: string;
+  label: string;
+  lines: string[];
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Narrow the raw unknown event to pull out a displayable line of text. */
+function eventToLine(event: unknown): string | null {
+  if (event == null || typeof event !== "object") return null;
+  const e = event as Record<string, unknown>;
+
+  // text_delta — most common streaming event
+  if (e.type === "text_delta" && typeof e.text === "string") {
+    return e.text;
+  }
+  // assistant message with content array
+  if (e.type === "assistant_message") {
+    return `[assistant_message]`;
+  }
+  // tool_use / tool_result summary
+  if (e.type === "tool_use" && typeof e.name === "string") {
+    return `[tool_use: ${e.name}]`;
+  }
+  if (e.type === "tool_result") {
+    return `[tool_result]`;
+  }
+  // run_complete / error
+  if (e.type === "run_complete") return `[run_complete]`;
+  if (e.type === "error" && typeof e.message === "string") return `[error: ${e.message}]`;
+
+  // Fallback: stringify the type field or the whole event
+  if (typeof e.type === "string") return `[${e.type}]`;
+  try {
+    return JSON.stringify(event).slice(0, 120);
+  } catch {
+    return "[unknown event]";
+  }
+}
+
+// ─── SessionPanel ─────────────────────────────────────────────────────────────
+
+interface SessionPanelProps {
+  session: SessionState;
+  onClose: (sessionId: string) => void;
+  onCancel: (sessionId: string) => void;
+}
+
+function SessionPanel({ session, onClose, onCancel }: SessionPanelProps): React.ReactElement {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Auto-scroll to bottom whenever lines change
+  useEffect(() => {
+    if (textareaRef.current) {
+      textareaRef.current.scrollTop = textareaRef.current.scrollHeight;
+    }
+  }, [session.lines]);
+
   return (
     <div
       style={{
         display: "flex",
         flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        height: "100%",
-        gap: 12,
-        padding: 24,
-        fontFamily: "ui-sans-serif, system-ui, sans-serif",
-        textAlign: "center",
+        gap: 6,
+        border: "1px solid #d1d5db",
+        borderRadius: 6,
+        padding: 10,
+        background: "#fff",
+        minWidth: 280,
+        flex: "1 1 280px",
       }}
     >
-      <div style={{ fontSize: 22, fontWeight: 600 }}>code-shell · desktop</div>
-      <div style={{ opacity: 0.6, fontSize: 13, maxWidth: 460, lineHeight: 1.6 }}>
-        Renderer is a placeholder. Main process boots; IPC bridge to{" "}
-        <code className="mono">window.codeShell</code> lands after the monorepo
-        split.
+      {/* Header */}
+      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        <span style={{ flex: 1, fontWeight: 600, fontSize: 12, color: "#374151" }}>
+          {session.label}
+        </span>
+        <button
+          onClick={() => onCancel(session.sessionId)}
+          style={smallBtn}
+          title="Cancel running turn"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={() => onClose(session.sessionId)}
+          style={{ ...smallBtn, background: "#fee2e2", color: "#b91c1c" }}
+          title="Close session and free resources"
+        >
+          Close
+        </button>
       </div>
-      <div style={{ marginTop: 16, fontSize: 12, opacity: 0.4 }}>
-        <code className="mono">
-          {typeof window !== "undefined" && (window as any).codeShell
-            ? "✓ preload bridge detected"
-            : "preload bridge: pending"}
-        </code>
+
+      {/* Session ID (truncated) */}
+      <div style={{ fontSize: 10, color: "#9ca3af", fontFamily: "monospace" }}>
+        {session.sessionId}
       </div>
+
+      {/* Output area */}
+      <textarea
+        ref={textareaRef}
+        readOnly
+        value={session.lines.join("")}
+        style={{
+          flex: 1,
+          minHeight: 180,
+          resize: "vertical",
+          fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+          fontSize: 12,
+          padding: 8,
+          border: "1px solid #e5e7eb",
+          borderRadius: 4,
+          background: "#f9fafb",
+          color: "#111827",
+          lineHeight: 1.5,
+        }}
+      />
+    </div>
+  );
+}
+
+const smallBtn: React.CSSProperties = {
+  fontSize: 11,
+  padding: "2px 8px",
+  border: "1px solid #d1d5db",
+  borderRadius: 4,
+  background: "#f9fafb",
+  color: "#374151",
+  cursor: "pointer",
+};
+
+// ─── App ──────────────────────────────────────────────────────────────────────
+
+let _sessionCounter = 0;
+
+export function App(): React.ReactElement {
+  const [sessions, setSessions] = useState<Map<string, SessionState>>(new Map());
+  // Stable ref so the stream handler closure never becomes stale
+  const sessionsRef = useRef<Map<string, SessionState>>(sessions);
+  sessionsRef.current = sessions;
+
+  const [taskInput, setTaskInput] = useState("hello from session");
+
+  // ── Stream event handler (stable reference via useCallback) ─────────────────
+  const handleStreamEvent = useCallback((env: StreamEnvelope) => {
+    const { sessionId, event } = env;
+    const line = eventToLine(event);
+    if (line == null) return;
+
+    setSessions((prev) => {
+      const session = prev.get(sessionId);
+      if (!session) return prev; // unknown sessionId — ignore
+      const next = new Map(prev);
+      next.set(sessionId, { ...session, lines: [...session.lines, line] });
+      return next;
+    });
+  }, []);
+
+  // ── Register / unregister on mount / unmount ─────────────────────────────────
+  useEffect(() => {
+    if (typeof window !== "undefined" && window.codeshell) {
+      window.codeshell.onStreamEvent(handleStreamEvent);
+    }
+    return () => {
+      if (typeof window !== "undefined" && window.codeshell) {
+        window.codeshell.offStreamEvent(handleStreamEvent);
+      }
+    };
+  }, [handleStreamEvent]);
+
+  // ── Start a new session ───────────────────────────────────────────────────────
+  const startSession = useCallback(() => {
+    if (!window.codeshell) return;
+    _sessionCounter += 1;
+    const sessionId = crypto.randomUUID();
+    const label = `Session ${_sessionCounter}`;
+    const task = taskInput.trim() || `hello from ${label}`;
+
+    const newSession: SessionState = { sessionId, label, lines: [] };
+    setSessions((prev) => {
+      const next = new Map(prev);
+      next.set(sessionId, newSession);
+      return next;
+    });
+
+    window.codeshell.run(task, { sessionId }).catch((err: unknown) => {
+      // Surface errors into the session output
+      setSessions((prev) => {
+        const session = prev.get(sessionId);
+        if (!session) return prev;
+        const next = new Map(prev);
+        const msg = err instanceof Error ? err.message : String(err);
+        next.set(sessionId, { ...session, lines: [...session.lines, `[run error: ${msg}]`] });
+        return next;
+      });
+    });
+  }, [taskInput]);
+
+  // ── Cancel a running turn ─────────────────────────────────────────────────────
+  const cancelSession = useCallback((sessionId: string) => {
+    window.codeshell?.cancel(sessionId).catch(() => {/* ignore */});
+  }, []);
+
+  // ── Close a session ───────────────────────────────────────────────────────────
+  const closeSession = useCallback((sessionId: string) => {
+    window.codeshell?.closeSession(sessionId).catch(() => {/* ignore */});
+    setSessions((prev) => {
+      const next = new Map(prev);
+      next.delete(sessionId);
+      return next;
+    });
+  }, []);
+
+  const sessionList = Array.from(sessions.values());
+  const bridgePresent = typeof window !== "undefined" && !!window.codeshell;
+
+  // ── Render ────────────────────────────────────────────────────────────────────
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        fontFamily: "ui-sans-serif, system-ui, sans-serif",
+        fontSize: 13,
+      }}
+    >
+      {/* Toolbar */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: "10px 14px",
+          borderBottom: "1px solid #e5e7eb",
+          background: "#f9fafb",
+          flexShrink: 0,
+        }}
+      >
+        <span style={{ fontWeight: 600, fontSize: 14, marginRight: 4 }}>code-shell · desktop</span>
+        <input
+          type="text"
+          value={taskInput}
+          onChange={(e) => setTaskInput(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && startSession()}
+          placeholder="Task prompt…"
+          style={{
+            flex: 1,
+            maxWidth: 360,
+            padding: "4px 8px",
+            fontSize: 12,
+            border: "1px solid #d1d5db",
+            borderRadius: 4,
+            outline: "none",
+          }}
+        />
+        <button
+          onClick={startSession}
+          disabled={!bridgePresent}
+          style={{
+            padding: "4px 14px",
+            fontSize: 12,
+            fontWeight: 600,
+            border: "none",
+            borderRadius: 4,
+            background: bridgePresent ? "#2563eb" : "#93c5fd",
+            color: "#fff",
+            cursor: bridgePresent ? "pointer" : "not-allowed",
+          }}
+        >
+          Start session
+        </button>
+        <span
+          style={{
+            fontSize: 11,
+            color: bridgePresent ? "#16a34a" : "#dc2626",
+            marginLeft: 4,
+          }}
+        >
+          {bridgePresent ? "bridge ready" : "bridge pending"}
+        </span>
+      </div>
+
+      {/* Sessions area */}
+      {sessionList.length === 0 ? (
+        <div
+          style={{
+            flex: 1,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 10,
+            opacity: 0.5,
+            fontSize: 13,
+          }}
+        >
+          <div>No active sessions.</div>
+          <div style={{ fontSize: 11 }}>
+            Enter a task and click <strong>Start session</strong> to open one.
+          </div>
+        </div>
+      ) : (
+        <div
+          style={{
+            flex: 1,
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 12,
+            padding: 12,
+            overflowY: "auto",
+            alignContent: "flex-start",
+          }}
+        >
+          {sessionList.map((s) => (
+            <SessionPanel
+              key={s.sessionId}
+              session={s}
+              onClose={closeSession}
+              onCancel={cancelSession}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/tui/src/cli/commands/repl.ts
+++ b/packages/tui/src/cli/commands/repl.ts
@@ -6,10 +6,14 @@
 
 import chalk from "chalk";
 import { Engine } from "@cjhyy/code-shell-core";
+import { EngineRuntime } from "@cjhyy/code-shell-core";
+import { ChatSessionManager } from "@cjhyy/code-shell-core";
 import { AgentServer } from "@cjhyy/code-shell-core";
 import { AgentClient } from "@cjhyy/code-shell-core";
 import { createInProcessTransport } from "@cjhyy/code-shell-core";
 import { SettingsManager } from "@cjhyy/code-shell-core";
+import { MCPManager } from "@cjhyy/code-shell-core";
+import { CostTracker } from "@cjhyy/code-shell-core";
 import { resolveApiKey } from "@cjhyy/code-shell-core";
 import { costTracker } from "@cjhyy/code-shell-core";
 import type { LLMConfig, PermissionMode } from "@cjhyy/code-shell-core";
@@ -122,10 +126,8 @@ export async function replCommand(options: ReplOptions): Promise<void> {
   const permissionMode = (options.permissionMode ?? "acceptEdits") as PermissionMode;
   const maxContextTokens = settings.context.maxTokens ?? 200_000;
 
-  // 1. Create the engine (server-side)
-  const engine = new Engine({
-    llm: llmConfig,
-    cwd,
+  // ── Shared config passed into every session engine ─────────────
+  const sharedCfg = {
     preset: options.preset ?? settings.agent.preset,
     enabledBuiltinTools: settings.agent.enabledBuiltinTools,
     disabledBuiltinTools: settings.agent.disabledBuiltinTools,
@@ -138,26 +140,82 @@ export async function replCommand(options: ReplOptions): Promise<void> {
     costStore: costTracker,
     mcpServers: settings.mcpServers,
     approvalBackend: getInteractiveApprovalBackend(),
+  };
+
+  // 1. Seed engine — calls populateModelPoolFromSettings() in ctor so the
+  //    model pool and tool registry are fully populated. Discarded after
+  //    resource extraction (never runs a task).
+  const seedEngine = new Engine({ llm: llmConfig, cwd });
+
+  // 2. Extract shared resources from seed engine
+  const modelPool = seedEngine.getModelPool();
+  const toolRegistry = seedEngine.getToolRegistry();
+  const resolvedLlmConfig = seedEngine.getConfig().llm;
+  // Build the shared SettingsManager wrapper (reuse from above).
+  const settingsManager = new SettingsManager(cwd);
+  // MCPManager: no-op holder satisfying EngineRuntime type; individual
+  // session engines connect to mcpServers from their config.
+  // TODO(future): aggregate MCP connections across sessions at the runtime level.
+  const mcpPool = new MCPManager(toolRegistry);
+  // CostTracker: fresh shared instance for this process.
+  // TODO(future): thread into Engine cost accounting once Engine reads runtime.costTracker.
+  const sessionCostTracker = new CostTracker();
+
+  // 3. Build the shared EngineRuntime
+  const runtime = new EngineRuntime({
+    modelPool,
+    toolRegistry,
+    settings: settingsManager,
+    mcpPool,
+    costTracker: sessionCostTracker,
   });
 
-  // 2. Create in-process transport pair
+  // 4. ChatSessionManager — single session "tui-main" (or resumed sid)
+  const chatManager = new ChatSessionManager({
+    runtime,
+    engineFactory: (slice) =>
+      new Engine({
+        llm: resolvedLlmConfig,
+        cwd,
+        runtime,
+        ...sharedCfg,
+        // Per-session overrides from the protocol request take precedence
+        ...(slice.permissionMode ? { permissionMode: slice.permissionMode } : {}),
+        ...(slice.preset ? { preset: slice.preset } : {}),
+        ...(slice.customSystemPrompt !== undefined ? { customSystemPrompt: slice.customSystemPrompt } : {}),
+        ...(slice.appendSystemPrompt !== undefined ? { appendSystemPrompt: slice.appendSystemPrompt } : {}),
+        ...(slice.maxTurns !== undefined ? { maxTurns: slice.maxTurns } : {}),
+        ...(slice.maxContextTokens !== undefined ? { maxContextTokens: slice.maxContextTokens } : {}),
+        ...(slice.cwd ? { cwd: slice.cwd } : {}),
+      }),
+    maxSessions: 4,
+    idleTtlMs: 30 * 60 * 1000,
+  });
+  chatManager.startIdleSweeper();
+
+  // 5. Create in-process transport pair
   const [serverTransport, clientTransport] = createInProcessTransport();
 
-  // 3. Wire up AgentServer (wraps engine, handles protocol)
-  const _server = new AgentServer({ engine, transport: serverTransport });
+  // 6. Wire up AgentServer (wraps chatManager, handles protocol)
+  const _server = new AgentServer({ chatManager, transport: serverTransport });
 
-  // 4. Create AgentClient (UI-side)
+  // 7. Create AgentClient (UI-side)
   const client = new AgentClient({ transport: clientTransport });
 
-  // 5. Launch Ink UI with the client
+  // Fixed sessionId — every user message in this REPL session routes to the
+  // same engine. Use the --resume id when provided so conversation history
+  // is correctly continued.
+  const tuiSessionId = options.resume ?? "tui-main";
+
+  // 8. Launch Ink UI with the client
   await startInkRepl({
     client,
     model,
     effort,
     maxTurns,
     cwd,
-    maxContextTokens: engine.maxContextTokens,
-    sessionId: options.resume,
+    maxContextTokens,
+    sessionId: tuiSessionId,
     prefill: options.prefill,
   });
 }

--- a/packages/tui/src/cli/commands/repl.ts
+++ b/packages/tui/src/cli/commands/repl.ts
@@ -54,8 +54,9 @@ function getEffortConfig(level: EffortLevel): { temperature: number; maxTokens: 
 export async function replCommand(options: ReplOptions): Promise<void> {
   const cwd = process.cwd();
 
-  // Load settings
-  let settings = new SettingsManager(cwd).get();
+  // Load settings — single SettingsManager instance reused throughout.
+  const settingsManager = new SettingsManager(cwd);
+  let settings = settingsManager.get();
 
   // Resolve API key.
   //
@@ -99,7 +100,7 @@ export async function replCommand(options: ReplOptions): Promise<void> {
     baseUrl = result.baseUrl;
     // Reload settings — the wizard has just persisted the model pool / arena
     // entries, and downstream code (e.g. /model) reads them from settings.
-    settings = new SettingsManager(cwd).get();
+    settings = settingsManager.get();
   }
 
   model = model ?? "anthropic/claude-opus-4-6";
@@ -151,8 +152,7 @@ export async function replCommand(options: ReplOptions): Promise<void> {
   const modelPool = seedEngine.getModelPool();
   const toolRegistry = seedEngine.getToolRegistry();
   const resolvedLlmConfig = seedEngine.getConfig().llm;
-  // Build the shared SettingsManager wrapper (reuse from above).
-  const settingsManager = new SettingsManager(cwd);
+  // settingsManager was hoisted to the top of replCommand; reused here.
   // MCPManager: no-op holder satisfying EngineRuntime type; individual
   // session engines connect to mcpServers from their config.
   // TODO(future): aggregate MCP connections across sessions at the runtime level.
@@ -188,7 +188,7 @@ export async function replCommand(options: ReplOptions): Promise<void> {
         ...(slice.maxContextTokens !== undefined ? { maxContextTokens: slice.maxContextTokens } : {}),
         ...(slice.cwd ? { cwd: slice.cwd } : {}),
       }),
-    maxSessions: 4,
+    maxSessions: 4,  // TUI is single-user; 4 accommodates a few sub-sessions without runaway resource use
     idleTtlMs: 30 * 60 * 1000,
   });
   chatManager.startIdleSweeper();

--- a/packages/tui/src/cli/commands/run.ts
+++ b/packages/tui/src/cli/commands/run.ts
@@ -5,8 +5,15 @@
  * but with a headless renderer instead of Ink UI.
  */
 
+import { randomUUID } from "node:crypto";
 import { Engine } from "@cjhyy/code-shell-core";
-import { createInProcessClient } from "@cjhyy/code-shell-core";
+import { EngineRuntime } from "@cjhyy/code-shell-core";
+import { ChatSessionManager } from "@cjhyy/code-shell-core";
+import { AgentServer } from "@cjhyy/code-shell-core";
+import { AgentClient } from "@cjhyy/code-shell-core";
+import { createInProcessTransport } from "@cjhyy/code-shell-core";
+import { MCPManager } from "@cjhyy/code-shell-core";
+import { CostTracker } from "@cjhyy/code-shell-core";
 import { SettingsManager } from "@cjhyy/code-shell-core";
 import { resolveApiKey } from "@cjhyy/code-shell-core";
 import { costTracker } from "@cjhyy/code-shell-core";
@@ -144,9 +151,8 @@ export async function runCommand(options: RunOptions): Promise<void> {
 
   const sandboxConfig = mergeSandboxConfig(settings.sandbox, "auto");
 
-  const engine = new Engine({
-    llm: llmConfig,
-    cwd,
+  // ── Shared config passed into every session engine ─────────────
+  const sharedCfg = {
     preset: options.preset ?? settings.agent.preset,
     enabledBuiltinTools: settings.agent.enabledBuiltinTools,
     disabledBuiltinTools: settings.agent.disabledBuiltinTools,
@@ -160,18 +166,73 @@ export async function runCommand(options: RunOptions): Promise<void> {
     mcpServers: settings.mcpServers,
     headless: true,
     sandbox: sandboxConfig,
+  };
+
+  // 1. Seed engine — populates model pool + tool registry via
+  //    populateModelPoolFromSettings() in ctor. Discarded after extraction.
+  const seedEngine = new Engine({ llm: llmConfig, cwd, headless: true });
+
+  // 2. Extract shared resources
+  const modelPool = seedEngine.getModelPool();
+  const toolRegistry = seedEngine.getToolRegistry();
+  const resolvedLlmConfig = seedEngine.getConfig().llm;
+  // Reuse the SettingsManager already constructed above (settingsManager).
+  // MCPManager: no-op holder for EngineRuntime; per-session engines connect
+  // via mcpServers in sharedCfg.
+  // TODO(future): aggregate MCP connections at the runtime level.
+  const mcpPool = new MCPManager(toolRegistry);
+  // CostTracker: fresh instance for this invocation.
+  // TODO(future): thread into Engine cost accounting via runtime.costTracker.
+  const runCostTracker = new CostTracker();
+
+  // 3. Build the shared EngineRuntime (reuse settingsManager from above)
+  const runtime = new EngineRuntime({
+    modelPool,
+    toolRegistry,
+    settings: settingsManager,
+    mcpPool,
+    costTracker: runCostTracker,
   });
+
+  // 4. ChatSessionManager — one session per `run` invocation (UUID)
+  const chatManager = new ChatSessionManager({
+    runtime,
+    engineFactory: (slice) =>
+      new Engine({
+        llm: resolvedLlmConfig,
+        cwd,
+        runtime,
+        ...sharedCfg,
+        // Per-session overrides from the protocol request take precedence
+        ...(slice.permissionMode ? { permissionMode: slice.permissionMode } : {}),
+        ...(slice.preset ? { preset: slice.preset } : {}),
+        ...(slice.customSystemPrompt !== undefined ? { customSystemPrompt: slice.customSystemPrompt } : {}),
+        ...(slice.appendSystemPrompt !== undefined ? { appendSystemPrompt: slice.appendSystemPrompt } : {}),
+        ...(slice.maxTurns !== undefined ? { maxTurns: slice.maxTurns } : {}),
+        ...(slice.maxContextTokens !== undefined ? { maxContextTokens: slice.maxContextTokens } : {}),
+        ...(slice.cwd ? { cwd: slice.cwd } : {}),
+      }),
+    maxSessions: 4,
+    idleTtlMs: 30 * 60 * 1000,
+  });
+  chatManager.startIdleSweeper();
+
+  // 5. Wire up in-process transport + server + client
+  const [serverTransport, clientTransport] = createInProcessTransport();
+  const _server = new AgentServer({ chatManager, transport: serverTransport });
+  const client = new AgentClient({ transport: clientTransport });
+
+  // Unique sessionId per run invocation; use --resume if provided.
+  const runSessionId = options.resume ?? `run-${randomUUID()}`;
 
   const outputFormat = options.output ?? (settings.output.format as OutputFormat) ?? "text";
   const renderer = createRenderer(outputFormat);
 
-  // Wire engine through the protocol layer; renderer consumes stream events.
-  const { client, close } = createInProcessClient(engine, {
-    onStream: (event) => renderer.onEvent(event),
-  });
+  // Wire renderer to stream events from client
+  client.onStreamEvent((envelope) => renderer.onEvent(envelope.event));
 
   try {
-    const result = await client.run(options.task, options.resume);
+    const result = await client.run(options.task, runSessionId);
 
     renderer.onComplete(result.text, result.reason, {
       sessionId: result.sessionId,
@@ -180,7 +241,7 @@ export async function runCommand(options: RunOptions): Promise<void> {
 
     process.exit(result.reason === "completed" ? 0 : 1);
   } finally {
-    close();
+    client.close();
   }
 }
 

--- a/packages/tui/src/cli/commands/run.ts
+++ b/packages/tui/src/cli/commands/run.ts
@@ -212,7 +212,7 @@ export async function runCommand(options: RunOptions): Promise<void> {
         ...(slice.maxContextTokens !== undefined ? { maxContextTokens: slice.maxContextTokens } : {}),
         ...(slice.cwd ? { cwd: slice.cwd } : {}),
       }),
-    maxSessions: 4,
+    maxSessions: 1,  // one-shot run; exactly one session per invocation
     idleTtlMs: 30 * 60 * 1000,
   });
   chatManager.startIdleSweeper();
@@ -231,6 +231,7 @@ export async function runCommand(options: RunOptions): Promise<void> {
   // Wire renderer to stream events from client
   client.onStreamEvent((envelope) => renderer.onEvent(envelope.event));
 
+  let exitCode = 1;
   try {
     const result = await client.run(options.task, runSessionId);
 
@@ -239,13 +240,14 @@ export async function runCommand(options: RunOptions): Promise<void> {
       turnCount: result.turnCount,
     });
 
-    process.exit(result.reason === "completed" ? 0 : 1);
+    exitCode = result.reason === "completed" ? 0 : 1;
   } finally {
     // Tear down in correct order: server first (aborts in-flight run, emits
     // shutdown notification through still-open transport), then client.
     server.close();
     client.close();
   }
+  process.exit(exitCode);
 }
 
 /**

--- a/packages/tui/src/cli/commands/run.ts
+++ b/packages/tui/src/cli/commands/run.ts
@@ -219,7 +219,7 @@ export async function runCommand(options: RunOptions): Promise<void> {
 
   // 5. Wire up in-process transport + server + client
   const [serverTransport, clientTransport] = createInProcessTransport();
-  const _server = new AgentServer({ chatManager, transport: serverTransport });
+  const server = new AgentServer({ chatManager, transport: serverTransport });
   const client = new AgentClient({ transport: clientTransport });
 
   // Unique sessionId per run invocation; use --resume if provided.
@@ -241,6 +241,9 @@ export async function runCommand(options: RunOptions): Promise<void> {
 
     process.exit(result.reason === "completed" ? 0 : 1);
   } finally {
+    // Tear down in correct order: server first (aborts in-flight run, emits
+    // shutdown notification through still-open transport), then client.
+    server.close();
     client.close();
   }
 }

--- a/packages/tui/src/ui/App.tsx
+++ b/packages/tui/src/ui/App.tsx
@@ -774,8 +774,11 @@ export function App({
 
   // Wire stream events from client
   useEffect(() => {
-    client.onStreamEvent(handleStreamEvent);
-    return () => client.offStreamEvent(handleStreamEvent);
+    // T10 changed onStreamEvent signature to pass an envelope { sessionId, event }.
+    // Unwrap to the legacy event-only signature; T12 will properly thread sessionId.
+    const envelopeHandler = (envelope: any) => handleStreamEvent(envelope.event);
+    client.onStreamEvent(envelopeHandler);
+    return () => client.offStreamEvent(envelopeHandler);
   }, [client, handleStreamEvent]);
 
   // Open the model selector by querying the pool from the server.

--- a/tests/chat-session-manager.test.ts
+++ b/tests/chat-session-manager.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "bun:test";
+import { ChatSessionManager } from "../packages/core/src/protocol/chat-session-manager.ts";
+
+function fakeRuntime(): any { return {}; }
+
+describe("ChatSessionManager", () => {
+  it("creates and reuses sessions by id", () => {
+    const m = new ChatSessionManager({
+      runtime: fakeRuntime(),
+      engineFactory: () => ({ run: async () => ({}), permissionMode: "default", planMode: false } as any),
+      maxSessions: 4,
+      idleTtlMs: 60_000,
+    });
+    const s1 = m.getOrCreate("A", { permissionMode: "default" } as any);
+    const s2 = m.getOrCreate("A", { permissionMode: "default" } as any);
+    expect(s1).toBe(s2);
+    expect(m.sessionCount()).toBe(1);
+  });
+
+  it("rejects with Overloaded when new session exceeds ceiling", () => {
+    const m = new ChatSessionManager({
+      runtime: fakeRuntime(),
+      engineFactory: () => ({ run: async () => ({}), permissionMode: "default", planMode: false } as any),
+      maxSessions: 2,
+      idleTtlMs: 60_000,
+    });
+    m.getOrCreate("A", {} as any);
+    m.getOrCreate("B", {} as any);
+    expect(() => m.getOrCreate("C", {} as any)).toThrow(/Overloaded/);
+    // Existing session still accessible:
+    expect(m.get("A")).toBeDefined();
+  });
+
+  it("close() removes the session", () => {
+    const m = new ChatSessionManager({
+      runtime: fakeRuntime(),
+      engineFactory: () => ({ run: async () => ({}), permissionMode: "default", planMode: false } as any),
+      maxSessions: 4,
+      idleTtlMs: 60_000,
+    });
+    m.getOrCreate("A", {} as any);
+    m.close("A");
+    expect(m.get("A")).toBeUndefined();
+  });
+
+  it("evicts idle sessions older than idleTtlMs", async () => {
+    const m = new ChatSessionManager({
+      runtime: fakeRuntime(),
+      engineFactory: () => ({ run: async () => ({}), permissionMode: "default", planMode: false } as any),
+      maxSessions: 4,
+      idleTtlMs: 20,
+    });
+    const s = m.getOrCreate("A", {} as any);
+    s.lastActivityAt = Date.now() - 1000;
+    m.sweepIdle();
+    expect(m.get("A")).toBeUndefined();
+  });
+});

--- a/tests/chat-session-queue.test.ts
+++ b/tests/chat-session-queue.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "bun:test";
+import { ChatSession } from "../packages/core/src/protocol/chat-session.ts";
+
+const fakeEngine: any = {
+  run: async (task: string) => {
+    // Simulate a slow turn so we can observe queueing.
+    await new Promise((r) => setTimeout(r, 30));
+    return { text: `done:${task}`, reason: "completed", sessionId: "s1", turnCount: 1, usage: {} };
+  },
+  permissionMode: "default",
+  planMode: false,
+};
+
+describe("ChatSession", () => {
+  it("runs a single turn", async () => {
+    const s = new ChatSession({ id: "s1", engine: fakeEngine });
+    const result = await s.enqueueTurn("hello", {});
+    expect(result.text).toBe("done:hello");
+    expect(s.isBusy()).toBe(false);
+  });
+
+  it("serializes turns from the same session", async () => {
+    const s = new ChatSession({ id: "s1", engine: fakeEngine });
+    const order: string[] = [];
+    const a = s.enqueueTurn("a", {}).then((r) => order.push(r.text));
+    const b = s.enqueueTurn("b", {}).then((r) => order.push(r.text));
+    expect(s.queueDepth()).toBe(1); // a running, b queued
+    await Promise.all([a, b]);
+    expect(order).toEqual(["done:a", "done:b"]);
+  });
+
+  it("cancel aborts in-flight turn", async () => {
+    const slowEngine: any = {
+      run: async (_task: string, opts: any) => {
+        await new Promise((resolve, reject) => {
+          opts.signal.addEventListener("abort", () => reject(new Error("aborted")));
+          setTimeout(resolve, 5000);
+        });
+        return { text: "never", reason: "completed", sessionId: "s1", turnCount: 1, usage: {} };
+      },
+      permissionMode: "default",
+      planMode: false,
+    };
+    const s = new ChatSession({ id: "s1", engine: slowEngine });
+    const p = s.enqueueTurn("slow", {});
+    setTimeout(() => s.cancel(), 10);
+    await expect(p).rejects.toThrow(/aborted/);
+  });
+});

--- a/tests/engine-runtime.test.ts
+++ b/tests/engine-runtime.test.ts
@@ -4,8 +4,29 @@ import { ModelPool } from "../packages/core/src/llm/model-pool.ts";
 
 describe("EngineRuntime", () => {
   it("exposes shared resources passed in at construction", () => {
-    const modelPool = {} as ModelPool;
-    const rt = new EngineRuntime({ modelPool });
+    const modelPool = {} as any;
+    const toolRegistry = {} as any;
+    const settings = {} as any;
+    const mcpPool = {} as any;
+    const costTracker = {} as any;
+    const rt = new EngineRuntime({ modelPool, toolRegistry, settings, mcpPool, costTracker });
     expect(rt.modelPool).toBe(modelPool);
+    expect(rt.toolRegistry).toBe(toolRegistry);
+    expect(rt.settings).toBe(settings);
+    expect(rt.mcpPool).toBe(mcpPool);
+    expect(rt.costTracker).toBe(costTracker);
+  });
+
+  it("holds toolRegistry, settings, mcpPool, costTracker", () => {
+    const modelPool = {} as any;
+    const toolRegistry = {} as any;
+    const settings = {} as any;
+    const mcpPool = {} as any;
+    const costTracker = {} as any;
+    const rt = new EngineRuntime({ modelPool, toolRegistry, settings, mcpPool, costTracker });
+    expect(rt.toolRegistry).toBe(toolRegistry);
+    expect(rt.settings).toBe(settings);
+    expect(rt.mcpPool).toBe(mcpPool);
+    expect(rt.costTracker).toBe(costTracker);
   });
 });

--- a/tests/engine-runtime.test.ts
+++ b/tests/engine-runtime.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from "bun:test";
+import { EngineRuntime } from "../packages/core/src/engine/runtime.ts";
+import { ModelPool } from "../packages/core/src/llm/model-pool.ts";
+
+describe("EngineRuntime", () => {
+  it("exposes shared resources passed in at construction", () => {
+    const modelPool = {} as ModelPool;
+    const rt = new EngineRuntime({ modelPool });
+    expect(rt.modelPool).toBe(modelPool);
+  });
+});

--- a/tests/engine-runtime.test.ts
+++ b/tests/engine-runtime.test.ts
@@ -40,7 +40,7 @@ describe("EngineRuntime", () => {
       costTracker: {} as any,
     });
     const e = new Engine({ runtime: rt, cwd: "/tmp", llm: { provider: "noop" } as any });
-    expect((e as any).runtime).toBe(rt);
+    expect(e.runtime).toBe(rt);
   });
 
   it("Engine exposes planMode/permissionMode as instance fields", async () => {

--- a/tests/engine-runtime.test.ts
+++ b/tests/engine-runtime.test.ts
@@ -29,4 +29,24 @@ describe("EngineRuntime", () => {
     expect(rt.mcpPool).toBe(mcpPool);
     expect(rt.costTracker).toBe(costTracker);
   });
+
+  it("Engine accepts a shared EngineRuntime via constructor", async () => {
+    const { Engine } = await import("../packages/core/src/engine/engine.ts");
+    const rt = new EngineRuntime({
+      modelPool: {} as any,
+      toolRegistry: {} as any,
+      settings: {} as any,
+      mcpPool: {} as any,
+      costTracker: {} as any,
+    });
+    const e = new Engine({ runtime: rt, cwd: "/tmp", llm: { provider: "noop" } as any });
+    expect((e as any).runtime).toBe(rt);
+  });
+
+  it("Engine exposes planMode/permissionMode as instance fields", async () => {
+    const { Engine } = await import("../packages/core/src/engine/engine.ts");
+    const e = new Engine({ cwd: "/tmp", llm: { provider: "noop" } as any, permissionMode: "plan" });
+    expect(e.permissionMode).toBe("plan");
+    expect(e.planMode).toBe(true);
+  });
 });

--- a/tests/plan-mode-isolation.test.ts
+++ b/tests/plan-mode-isolation.test.ts
@@ -14,4 +14,10 @@ describe("plan mode isolation", () => {
     expect(mod.setInPlanMode).toBeUndefined();
     expect(mod.isInPlanMode).toBeUndefined();
   });
+
+  it("permission.ts no longer exports setRuntimeBypass/isRuntimeBypass", async () => {
+    const mod: any = await import("../packages/core/src/tool-system/permission.ts");
+    expect(mod.setRuntimeBypass).toBeUndefined();
+    expect(mod.isRuntimeBypass).toBeUndefined();
+  });
 });

--- a/tests/plan-mode-isolation.test.ts
+++ b/tests/plan-mode-isolation.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "bun:test";
+
+describe("plan mode isolation", () => {
+  it("two ToolContexts can carry different planMode values", () => {
+    // After refactor: there is no global getter. Each engine surfaces its own.
+    const ctxA = { planMode: true } as any;
+    const ctxB = { planMode: false } as any;
+    expect(ctxA.planMode).toBe(true);
+    expect(ctxB.planMode).toBe(false);
+  });
+
+  it("plan.ts no longer exports setInPlanMode/isInPlanMode", async () => {
+    const mod: any = await import("../packages/core/src/tool-system/builtin/plan.ts");
+    expect(mod.setInPlanMode).toBeUndefined();
+    expect(mod.isInPlanMode).toBeUndefined();
+  });
+});

--- a/tests/plan-tool.test.ts
+++ b/tests/plan-tool.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "bun:test";
+import { Engine } from "../packages/core/src/engine/engine.ts";
+
+describe("Plan tool", () => {
+  it("toggles engine.planMode through ToolContext", async () => {
+    const e = new Engine({ cwd: "/tmp", llm: { provider: "noop" } as any, permissionMode: "default" });
+    expect(e.planMode).toBe(false);
+    // Simulate Plan tool execution. Engine should pass itself into ctx so
+    // the tool can call ctx.engine.setPlanMode(true).
+    const ctx = (e as any).buildToolContext();
+    ctx.engine.setPlanMode(true);
+    expect(e.planMode).toBe(true);
+  });
+});

--- a/tests/protocol/multi-session.test.ts
+++ b/tests/protocol/multi-session.test.ts
@@ -1,0 +1,109 @@
+/**
+ * AgentServer multi-session tests.
+ *
+ * Verifies that the rewritten AgentServer dispatches through ChatSessionManager:
+ *   1. Two sessions run concurrently without cross-talk.
+ *   2. Missing sessionId → -32602 InvalidParams.
+ *   3. Same-session second send queues behind the first.
+ */
+import { describe, it, expect } from "bun:test";
+import { AgentServer } from "../../packages/core/src/protocol/server.ts";
+import { ChatSessionManager } from "../../packages/core/src/protocol/chat-session-manager.ts";
+import { createInProcessTransport } from "../../packages/core/src/protocol/transport.ts";
+import { AgentClient } from "../../packages/core/src/protocol/client.ts";
+import type { AgentStreamEventNotification } from "../../packages/core/src/protocol/types.ts";
+
+function fakeRuntime(): any {
+  return {};
+}
+
+/**
+ * Returns a ChatSessionManager whose engineFactory creates a fake engine.
+ * Each fake engine records onStream callbacks and simulates a short async run.
+ */
+function makeManager(maxSessions = 8) {
+  return new ChatSessionManager({
+    runtime: fakeRuntime(),
+    engineFactory: (_slice: any) => ({
+      permissionMode: "default",
+      planMode: false,
+      setPlanMode: (_v: boolean) => {},
+      setPermissionMode: (_m: string) => {},
+      setAskUser: (_fn: any) => {},
+      run: async (task: string, opts: any) => {
+        opts.onStream?.({ type: "text_delta", text: `t:${task}` });
+        await new Promise((r) => setTimeout(r, 20));
+        opts.onStream?.({ type: "turn_complete" });
+        return {
+          text: `done:${task}`,
+          reason: "completed" as const,
+          sessionId: opts.sessionId ?? "test",
+          turnCount: 1,
+          usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        };
+      },
+    }),
+    maxSessions,
+    idleTtlMs: 60_000,
+  });
+}
+
+describe("AgentServer multi-session", () => {
+  it("runs two sessions in parallel without cross-talk", async () => {
+    const [serverT, clientT] = createInProcessTransport();
+    const cm = makeManager();
+    new AgentServer({ chatManager: cm, transport: serverT });
+    const client = new AgentClient({ transport: clientT });
+
+    const eventsA: any[] = [];
+    const eventsB: any[] = [];
+    client.onStreamEvent((env: AgentStreamEventNotification) => {
+      if (env.sessionId === "A") eventsA.push(env.event);
+      if (env.sessionId === "B") eventsB.push(env.event);
+    });
+
+    const [a, b] = await Promise.all([
+      client.run({ sessionId: "A", task: "hello-a" }),
+      client.run({ sessionId: "B", task: "hello-b" }),
+    ]);
+
+    expect(a.text).toBe("done:hello-a");
+    expect(b.text).toBe("done:hello-b");
+    expect(eventsA.some((e) => e.type === "text_delta" && e.text === "t:hello-a")).toBe(true);
+    expect(eventsB.some((e) => e.type === "text_delta" && e.text === "t:hello-b")).toBe(true);
+    // Each session only sees its own text_delta events
+    const aCrossEvents = eventsA.filter(
+      (e) => e.type === "text_delta" && e.text !== "t:hello-a",
+    );
+    expect(aCrossEvents).toHaveLength(0);
+  });
+
+  it("agent/run without sessionId returns -32602", async () => {
+    const [serverT, clientT] = createInProcessTransport();
+    const cm = makeManager();
+    new AgentServer({ chatManager: cm, transport: serverT });
+    const client = new AgentClient({ transport: clientT });
+
+    // task only, no sessionId — should reject with InvalidParams
+    await expect(
+      client.run({ task: "x", sessionId: "" } as any),
+    ).rejects.toMatchObject({ code: -32602 });
+  });
+
+  it("same-session second send queues behind the first", async () => {
+    const [serverT, clientT] = createInProcessTransport();
+    const cm = makeManager();
+    new AgentServer({ chatManager: cm, transport: serverT });
+    const client = new AgentClient({ transport: clientT });
+
+    const order: string[] = [];
+    const a = client.run({ sessionId: "A", task: "a" }).then((r) => {
+      order.push(r.text);
+    });
+    const b = client.run({ sessionId: "A", task: "b" }).then((r) => {
+      order.push(r.text);
+    });
+    await Promise.all([a, b]);
+    expect(order).toEqual(["done:a", "done:b"]);
+  });
+});

--- a/tests/tool-context.test.ts
+++ b/tests/tool-context.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from "bun:test";
+import type { ToolContext } from "../packages/core/src/tool-system/context.ts";
+
+describe("ToolContext", () => {
+  it("carries planMode flag", () => {
+    const ctx: Partial<ToolContext> = { planMode: true };
+    expect(ctx.planMode).toBe(true);
+  });
+});

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -7,7 +7,7 @@ import { grepTool } from "../packages/core/src/tool-system/builtin/grep.js";
 import { webFetchTool } from "../packages/core/src/tool-system/builtin/web-fetch.js";
 import { askUserTool } from "../packages/core/src/tool-system/builtin/ask-user.js";
 import type { ToolContext } from "../packages/core/src/tool-system/context.js";
-import { enterPlanModeTool, exitPlanModeTool, resetPlanMode } from "../packages/core/src/tool-system/builtin/plan.js";
+import { enterPlanModeTool, exitPlanModeTool } from "../packages/core/src/tool-system/builtin/plan.js";
 import { mkdtempSync, writeFileSync, rmSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -169,23 +169,32 @@ describe("Plan mode tools", () => {
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), "plan-test-"));
-    resetPlanMode();
   });
   afterEach(() => {
-    resetPlanMode();
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("enters and exits plan mode", async () => {
-    const enterResult = await enterPlanModeTool({});
+  it("enters plan mode (ctx.planMode=false → returns entered message)", async () => {
+    const ctx = { planMode: false } as unknown as ToolContext;
+    const enterResult = await enterPlanModeTool({}, ctx);
     expect(enterResult).toContain("Entered plan mode");
+  });
 
-    const exitResult = await exitPlanModeTool({});
+  it("returns informative message when already in plan mode", async () => {
+    const ctx = { planMode: true } as unknown as ToolContext;
+    const result = await enterPlanModeTool({}, ctx);
+    expect(result).toContain("Already in plan mode");
+  });
+
+  it("exits plan mode (ctx.planMode=true → returns exited message)", async () => {
+    const ctx = { planMode: true } as unknown as ToolContext;
+    const exitResult = await exitPlanModeTool({}, ctx);
     expect(exitResult).toContain("Exited plan mode");
   });
 
   it("returns informative message when exiting without entering", async () => {
-    const result = await exitPlanModeTool({});
+    const ctx = { planMode: false } as unknown as ToolContext;
+    const result = await exitPlanModeTool({}, ctx);
     expect(result).toContain("Not currently in plan mode");
   });
 });

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -174,26 +174,32 @@ describe("Plan mode tools", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("enters plan mode (ctx.planMode=false → returns entered message)", async () => {
-    const ctx = { planMode: false } as unknown as ToolContext;
+  it("enters plan mode (ctx.engine.planMode=false → returns entered message)", async () => {
+    const engine = { planMode: false, setPlanMode(v: boolean) { this.planMode = v; } };
+    const ctx = { planMode: false, engine } as unknown as ToolContext;
     const enterResult = await enterPlanModeTool({}, ctx);
     expect(enterResult).toContain("Entered plan mode");
+    expect(engine.planMode).toBe(true);
   });
 
   it("returns informative message when already in plan mode", async () => {
-    const ctx = { planMode: true } as unknown as ToolContext;
+    const engine = { planMode: true, setPlanMode(v: boolean) { this.planMode = v; } };
+    const ctx = { planMode: true, engine } as unknown as ToolContext;
     const result = await enterPlanModeTool({}, ctx);
     expect(result).toContain("Already in plan mode");
   });
 
-  it("exits plan mode (ctx.planMode=true → returns exited message)", async () => {
-    const ctx = { planMode: true } as unknown as ToolContext;
+  it("exits plan mode (ctx.engine.planMode=true → returns exited message)", async () => {
+    const engine = { planMode: true, setPlanMode(v: boolean) { this.planMode = v; } };
+    const ctx = { planMode: true, engine } as unknown as ToolContext;
     const exitResult = await exitPlanModeTool({}, ctx);
     expect(exitResult).toContain("Exited plan mode");
+    expect(engine.planMode).toBe(false);
   });
 
   it("returns informative message when exiting without entering", async () => {
-    const ctx = { planMode: false } as unknown as ToolContext;
+    const engine = { planMode: false, setPlanMode(v: boolean) { this.planMode = v; } };
+    const ctx = { planMode: false, engine } as unknown as ToolContext;
     const result = await exitPlanModeTool({}, ctx);
     expect(result).toContain("Not currently in plan mode");
   });


### PR DESCRIPTION
## Summary

Fix the "second chat tab silently drops messages" bug by replacing the single-flag `protocol/server.ts` with a per-`sessionId` `ChatSessionManager`. Mirrors the Codex app-server / Claude Code `query.ts` model: multi-session concurrent, per-session turns sequential. RunManager (managed runs) is deliberately left alone — chat and managed paths remain two parallel subsystems.

Implements `docs/superpowers/specs/2026-05-26-multi-session-chat-runtime-design.md` via `docs/superpowers/plans/2026-05-26-multi-session-chat-runtime.md` (only on main).

### Three root-cause fixes from the spec (§1.2)

1. **Server layer**: replaced `this.running` single boolean flag with `ChatSessionManager` (per-`sessionId` Map<sessionId, ChatSession>). Different sessions run truly in parallel; same-session second send queues behind the first via FIFO `pump()`.
2. **Renderer layer (scaffold)**: `App.tsx` routes stream events by `envelope.sessionId` from a `Map<sessionId, SessionState>`, with proper `useEffect` cleanup via `offStreamEvent`.
3. **Subagent attribution**: stream notifications always carry `sessionId` on the wrapping `agent/streamEvent` envelope; subagent events that arrive after the parent `turn_complete` still route correctly because routing is keyed on session, not on turn lifecycle.

### Architecture (matches spec §3.1)

```
EngineRuntime         (one per worker — shared model pool, tool registry, settings, mcp pool, cost tracker)
└── Engine            (one per ChatSession — owns conversationHistory, permissionMode, planMode, askUser, abortSignal)
ChatSession           (one per UI chat tab — owns Engine + FIFO turn queue + per-session pending approvals)
ChatSessionManager    (Map<sessionId, ChatSession> + global ceiling + idle eviction)
AgentServer           (thin dispatcher over ChatSessionManager + optional RunManager)
```

### Protocol changes (§4)

- `Methods.CloseSession` (`agent/closeSession`) added.
- Error codes: `Overloaded -32001` and `SessionClosed -32004` added; `AlreadyRunning -32003` removed.
- `RunParams.sessionId` is now required.
- Every `agent/streamEvent` and `agent/approvalRequest` notification carries `sessionId` on the envelope.

### Singleton removals

- Deleted `setRuntimeBypass` / `isRuntimeBypass` module-level state from `tool-system/permission.ts`. Reads now go through `ToolContext.permissionMode` / instance `Engine.permissionMode`.
- Deleted `setInPlanMode` / `isInPlanMode` / `resetPlanMode` / `restorePlanMode` from `tool-system/builtin/plan.ts`. Plan tool calls `ctx.engine.setPlanMode(...)`; consumers read `ctx.planMode` (populated by `Engine.buildToolContext()`).

### Commits (26 total)

```
55448c6 → 6c5f2ca   feat: 15 plan tasks + 8 review-driven fixes + 1 final pre-merge fix
```

## Test Plan

- [x] Core unit tests pass (672 pass / 21 fail — all 21 are pre-existing TUI/Ink rendering tests unrelated to this work; failure set diff vs pre-branch baseline is empty)
- [x] Typecheck clean across `core`, `tui`, `desktop` packages
- [x] Build clean (`bun run build` exits 0 for both `@cjhyy/code-shell-core` and `@cjhyy/code-shell-tui`)
- [x] `agent-server-stdio` smoke test: emits `agent/status: ready` within ~150ms and waits for input
- [x] Multi-session integration test (`tests/protocol/multi-session.test.ts`): two sessions in parallel without cross-talk; missing sessionId returns -32602; same-session second send queues correctly
- [x] Plan-mode isolation test confirms module singletons are absent
- [ ] Manual desktop smoke: open two tabs, run in parallel, verify (deferred — needs reconcile with main's rich App.tsx, see Merge notes below)
- [ ] Manual TUI smoke: REPL boots, basic message round-trips (deferred — needs API key)

## Merge notes (important)

**This branch was off `b4b3032` (older snapshot) and `main` has diverged significantly since.** Specifically:

- `main`'s `packages/desktop/src/renderer/App.tsx` is a rich multi-tab chat UI with sidebar, tool-call folding, settings modal, etc. This branch's `App.tsx` is a minimal 333-line sessionId-routing scaffold. **Do NOT replace main's App.tsx with this branch's version.** Instead, graft the routing primitives (`Map<sessionId, SessionState>`, `useCallback(handleStreamEvent)`, `sessionsRef`, `offStreamEvent` on unmount) into main's existing structure.
- `main`'s desktop preload (`packages/desktop/src/preload/index.ts`) is also more evolved. Merge the new type additions (`StreamEnvelope`, `ApprovalEnvelope`, named `onStreamEvent` / `offStreamEvent` / `onApprovalRequest` / `offApprovalRequest`, `closeSession`) into main's preload; do not discard main's `ipcMain` wiring.
- `main`'s `packages/desktop/src/main/index.ts` should be kept entirely (this branch's stub does not have the `AgentBridge`).
- The core (`packages/core/`) and TUI (`packages/tui/`) deltas are additive and should merge cleanly. Public API stays backward-compatible via `createInProcessClient`'s `engine:` shim.

## Known carry-forwards (filed for follow-up tickets)

| # | Item | Severity |
|---|------|----------|
| 1 | `taskManager.setStreamCallback` not wired in `handleRunMulti` — task_update events from TaskCreate/TaskUpdate tools aren't forwarded in multi-session mode | Important |
| 2 | `ChatSession.pendingApprovals` not yet populated by Engine — per-session approval flow needs engine-side wiring | Important |
| 3 | Subagent spawn (`engine.ts:482`) doesn't pass `runtime: this.runtime` — subagents bypass the shared pool | Minor |
| 4 | Legacy `this.running` / `this.abortController` / `handleRunLegacy` kept in `server.ts` for `createInProcessClient(engine)` callers — migrate and delete in follow-up | Minor |
| 5 | `runtime.mcpPool` / `runtime.costTracker` / `runtime.settings` are placeholders — Engine doesn't yet read these from runtime, each per-session Engine constructs its own | Minor |
| 6 | `_interactiveBackend` singleton in `permission.ts:308` — same anti-pattern as the removed `_runtimeBypass`, but bounded to single-process TUI use | Minor |

🤖 Generated with [Claude Code](https://claude.com/claude-code)