### PR TITLE
feat(desktop): let panel tasks select configured models

### DIFF
--- a/docs/panel-apps.md
+++ b/docs/panel-apps.md
@@ -171,10 +171,23 @@ profiles, hooks, MCP servers, or unrelated Skills. The app supplies a hard
 per-run tool allowlist and may select only a Skill bundled in its own reviewed
 manifest. Normal tool permission and approval policy still applies.
 
+Panel API v9 adds `agent.task.models`, which returns only secret-free configured
+text connections as `{ id, providerId, provider, model, label }` rows plus the
+effective `defaultModel`. Passing one returned connection `id` as the optional
+`model` field of `agent.task.start` selects it for that Task; omitting `model`
+continues to follow the effective CodeShell default. Provider credentials,
+endpoints, and model parameter values never cross the Panel guest boundary.
+It also adds secret-free `process.info` (`platform`, `arch`, and Linux `libc`) and the
+`user-bin` known directory. The latter is a Host-owned per-user executable
+directory automatically included in Panel process lookup and child `PATH`, so
+reviewed apps can install a verified standalone tool without guessing a system
+directory or changing the user's shell profile.
+
 ```js
 const task = await window.codeshellPanel.call("agent.task.start", {
   key: "repair",
   label: "Repair local dependency",
+  model: "my-fast-model",
   prompt: "Use the bundled setup Skill and verify the result.",
   skill: "my-panel-app:setup",
   toolNames: ["Skill", "Bash"],

--- a/packages/desktop/scripts/e2e-panel-app.mjs
+++ b/packages/desktop/scripts/e2e-panel-app.mjs
@@ -337,7 +337,7 @@ try {
   assert(context.cwd === projectDir, "workspace permission was not scoped correctly");
   assert(context.trusted === false, "workspace trust must be decided by main");
   assert(context.theme === "dark" && context.locale === "en", "host context was not bound");
-  assert(context.apiVersion === 8, "Panel App bridge API v8 was not exposed");
+  assert(context.apiVersion === 9, "Panel App bridge API v9 was not exposed");
   const agentToolResult = await win.evaluate(
     ({ appDescriptorId }) =>
       window.codeshell.invokePanelAppAgentTool({

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -386,6 +386,7 @@ import {
   themeAssetUrl,
 } from "./theme-asset-protocol.js";
 import { PanelAppBridge } from "./panel-app-bridge.js";
+import { buildPanelAgentTaskModelCatalog } from "./panel-app-agent-task-models.js";
 import {
   listMarketplacesForUi,
   loadMarketplaceForUi,
@@ -580,6 +581,11 @@ const panelAppBridge = new PanelAppBridge({
   isWorkspaceTrusted: (cwd) => getTrustCachedSync(cwd) === "trusted",
   isPanelAppBound: isPanelAppBoundToProject,
   getAgentBridge: () => bridge,
+  agentTaskModels: (cwd) =>
+    buildPanelAgentTaskModelCatalog(
+      new SettingsManager(cwd, "full", getTrustCachedSync(cwd) === "trusted").get(),
+      getMergedCatalog(),
+    ),
   showNotification: ({ title, body }) => {
     if (!Notification.isSupported()) return false;
     // Best-effort, same as the app's own agent notifications.

--- a/packages/desktop/src/main/panel-app-agent-task-models.test.ts
+++ b/packages/desktop/src/main/panel-app-agent-task-models.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { buildPanelAgentTaskModelCatalog } from "./panel-app-agent-task-models.js";
+
+describe("buildPanelAgentTaskModelCatalog", () => {
+  test("returns configured text connections without credentials or endpoints", () => {
+    const result = buildPanelAgentTaskModelCatalog(
+      {
+        credentials: [{ id: "secret", apiKey: "never-return-this" }],
+        defaults: { text: "fast" },
+        modelConnections: [
+          {
+            id: "fast",
+            catalogId: "openai",
+            tag: "text",
+            model: "gpt-5-mini",
+            credentialId: "secret",
+            baseUrl: "https://private.example.test",
+          },
+          { id: "image", catalogId: "openai", tag: "image", model: "gpt-image-1" },
+          { id: "stale", catalogId: "missing", tag: "text", model: "unknown" },
+        ],
+      },
+      [
+        {
+          id: "openai",
+          displayName: "OpenAI",
+          modelPresets: [{ value: "gpt-5-mini", label: "GPT-5 mini" }],
+        },
+      ],
+    );
+
+    expect(result).toEqual({
+      defaultModel: "fast",
+      models: [
+        {
+          id: "fast",
+          providerId: "openai",
+          provider: "OpenAI",
+          model: "gpt-5-mini",
+          label: "GPT-5 mini",
+        },
+      ],
+    });
+    expect(JSON.stringify(result)).not.toContain("never-return-this");
+    expect(JSON.stringify(result)).not.toContain("private.example.test");
+  });
+
+  test("omits an invalid default and de-duplicates connection ids", () => {
+    const result = buildPanelAgentTaskModelCatalog(
+      {
+        defaults: { text: "missing" },
+        modelConnections: [
+          { id: "same", catalogId: "custom", tag: "text", model: "one" },
+          { id: "same", catalogId: "custom", tag: "text", model: "two" },
+        ],
+      },
+      [{ id: "custom", displayName: "Custom" }],
+    );
+    expect(result.defaultModel).toBeUndefined();
+    expect(result.models).toHaveLength(1);
+    expect(result.models[0]?.model).toBe("one");
+  });
+});

--- a/packages/desktop/src/main/panel-app-agent-task-models.ts
+++ b/packages/desktop/src/main/panel-app-agent-task-models.ts
@@ -1,0 +1,83 @@
+export interface PanelAgentTaskModelOption {
+  id: string;
+  providerId: string;
+  provider: string;
+  model: string;
+  label: string;
+}
+
+export interface PanelAgentTaskModelCatalog {
+  defaultModel?: string;
+  models: PanelAgentTaskModelOption[];
+}
+
+interface ModelConnectionLike {
+  id?: unknown;
+  catalogId?: unknown;
+  tag?: unknown;
+  model?: unknown;
+}
+
+interface CatalogEntryLike {
+  id?: unknown;
+  displayName?: unknown;
+  modelPresets?: Array<{ value?: unknown; label?: unknown }>;
+}
+
+function boundedText(value: unknown, max: number): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const text = value.trim();
+  if (!text || text.length > max || /[\r\n\0]/.test(text)) return undefined;
+  return text;
+}
+
+/**
+ * Build the secret-free model catalog exposed to a Panel App.
+ *
+ * Connections are the engine's real pool keys. Credentials, base URLs, and
+ * parameter values deliberately never cross the guest boundary.
+ */
+export function buildPanelAgentTaskModelCatalog(
+  settings: unknown,
+  catalog: readonly CatalogEntryLike[],
+): PanelAgentTaskModelCatalog {
+  const source =
+    settings && typeof settings === "object" ? (settings as Record<string, unknown>) : {};
+  const entries = new Map(
+    catalog.flatMap((entry) => {
+      const id = boundedText(entry.id, 256);
+      return id ? [[id, entry] as const] : [];
+    }),
+  );
+  const connections = Array.isArray(source.modelConnections)
+    ? (source.modelConnections as ModelConnectionLike[])
+    : [];
+  const models: PanelAgentTaskModelOption[] = [];
+  const seen = new Set<string>();
+
+  for (const connection of connections) {
+    if (connection?.tag !== "text") continue;
+    const id = boundedText(connection.id, 256);
+    const providerId = boundedText(connection.catalogId, 256);
+    const model = boundedText(connection.model, 512);
+    if (!id || !providerId || !model || seen.has(id)) continue;
+    const entry = entries.get(providerId);
+    if (!entry) continue;
+    const provider = boundedText(entry.displayName, 256) ?? providerId;
+    const preset = Array.isArray(entry.modelPresets)
+      ? entry.modelPresets.find((candidate) => candidate?.value === model)
+      : undefined;
+    const label = boundedText(preset?.label, 512) ?? model;
+    seen.add(id);
+    models.push({ id, providerId, provider, model, label });
+  }
+
+  const defaults =
+    source.defaults && typeof source.defaults === "object"
+      ? (source.defaults as Record<string, unknown>)
+      : {};
+  const requestedDefault = boundedText(defaults.text, 256);
+  const defaultModel =
+    requestedDefault && seen.has(requestedDefault) ? requestedDefault : undefined;
+  return { ...(defaultModel ? { defaultModel } : {}), models };
+}

--- a/packages/desktop/src/main/panel-app-agent-task-service.test.ts
+++ b/packages/desktop/src/main/panel-app-agent-task-service.test.ts
@@ -47,6 +47,7 @@ describe("PanelAppAgentTaskService", () => {
       prompt: "initialize",
       label: "Initialize downloader",
       key: "setup",
+      model: "fast-model",
       skill: "video-download:video-download-setup",
       toolNames: ["Panel", "Bash"],
       maxTurns: 12,
@@ -59,12 +60,14 @@ describe("PanelAppAgentTaskService", () => {
     expect(completed.result?.text).toBe("ready");
     expect(calls[0]).toMatchObject({
       sessionId: "panel-task-2",
+      model: "fast-model",
       toolNames: ["Panel", "Bash", "Skill"],
       skillNames: ["video-download:video-download-setup"],
       maxTurns: 12,
       maxContextTokens: 32768,
     });
     expect(events.map((event) => event.status)).toEqual(["queued", "running", "completed"]);
+    expect(completed.model).toBe("fast-model");
   });
 
   test("deduplicates an active key and rejects another app's Skill", async () => {
@@ -92,6 +95,9 @@ describe("PanelAppAgentTaskService", () => {
         skill: "other:secret",
       }),
     ).toThrow(/not bundled/);
+    expect(() => service.start(owner(), { prompt: "x", label: "X", model: "bad\nmodel" })).toThrow(
+      /connection id/,
+    );
     finish();
   });
 

--- a/packages/desktop/src/main/panel-app-agent-task-service.ts
+++ b/packages/desktop/src/main/panel-app-agent-task-service.ts
@@ -31,6 +31,7 @@ export interface PanelAgentTaskView {
   key?: string;
   label: string;
   status: PanelAgentTaskStatus;
+  model?: string;
   skill?: string;
   createdAt: number;
   updatedAt: number;
@@ -59,6 +60,7 @@ export interface PanelAgentTaskStartInput {
   prompt?: unknown;
   label?: unknown;
   key?: unknown;
+  model?: unknown;
   skill?: unknown;
   toolNames?: unknown;
   maxTurns?: unknown;
@@ -71,6 +73,7 @@ export interface PanelAgentTaskRuntime {
     owner: PanelAgentTaskOwner;
     prompt: string;
     label: string;
+    model?: string;
     toolNames: string[];
     skillNames: string[];
     maxTurns: number;
@@ -91,6 +94,7 @@ interface StoredPanelAgentTask extends PanelAgentTaskView {
   sessionId: string;
   owner: PanelAgentTaskOwner;
   prompt: string;
+  model?: string;
   toolNames: string[];
   skillNames: string[];
   maxTurns: number;
@@ -135,6 +139,7 @@ function publicTask(task: StoredPanelAgentTask): PanelAgentTaskView {
     ...(task.key ? { key: task.key } : {}),
     label: task.label,
     status: task.status,
+    ...(task.model ? { model: task.model } : {}),
     ...(task.skill ? { skill: task.skill } : {}),
     createdAt: task.createdAt,
     updatedAt: task.updatedAt,
@@ -171,6 +176,10 @@ export class PanelAppAgentTaskService {
     const key = raw.key === undefined ? undefined : String(raw.key);
     if (key !== undefined && !TASK_KEY.test(key)) {
       throw new Error("agent.task.start key must match ^[a-z][a-z0-9_-]{0,63}$");
+    }
+    const model = raw.model === undefined ? undefined : String(raw.model).trim();
+    if (model !== undefined && (!model || model.length > 256 || /[\r\n\0]/.test(model))) {
+      throw new Error("agent.task.start model must be a bounded non-empty connection id");
     }
     const skill = raw.skill === undefined ? undefined : String(raw.skill);
     if (skill !== undefined && !owner.availableSkills.includes(skill)) {
@@ -214,6 +223,7 @@ export class PanelAppAgentTaskService {
       ...(key ? { key } : {}),
       label,
       status: "queued",
+      ...(model ? { model } : {}),
       ...(skill ? { skill } : {}),
       createdAt,
       updatedAt: createdAt,
@@ -292,6 +302,7 @@ export class PanelAppAgentTaskService {
         owner: task.owner,
         prompt: task.prompt,
         label: task.label,
+        ...(task.model ? { model: task.model } : {}),
         toolNames: task.toolNames,
         skillNames: task.skillNames,
         maxTurns: task.maxTurns,

--- a/packages/desktop/src/main/panel-app-bridge.ts
+++ b/packages/desktop/src/main/panel-app-bridge.ts
@@ -22,7 +22,11 @@ import type { AgentBridge } from "./agent-bridge.js";
 import { claimPanelHostOwnerForRun } from "./panel-host-routing.js";
 import type { PanelAppProtocolResource } from "./panel-app-protocol.js";
 import { preparePanelApp } from "./panel-app-protocol.js";
-import { PanelAppProcessService, type PanelProcessOwner } from "./panel-app-process-service.js";
+import {
+  PanelAppProcessService,
+  panelProcessInfo,
+  type PanelProcessOwner,
+} from "./panel-app-process-service.js";
 import {
   DEFAULT_PANEL_APP_STORAGE_QUOTA_BYTES,
   panelAppStorageKey,
@@ -37,6 +41,7 @@ import {
   type PanelAgentTaskProgressInput,
   type PanelAgentTaskStartInput,
 } from "./panel-app-agent-task-service.js";
+import type { PanelAgentTaskModelCatalog } from "./panel-app-agent-task-models.js";
 import {
   PANEL_APP_API_VERSION,
   type PanelAppBindInput,
@@ -125,6 +130,8 @@ export interface PanelAppBridgeOptions {
   /** Rechecked on prepare, bind, Agent invocation, and every Host call. */
   isPanelAppBound(projectPath: string, appId: string): boolean;
   getAgentBridge(): AgentBridge | null;
+  /** Secret-free configured text connections available to isolated Panel Tasks. */
+  agentTaskModels?(cwd: string): PanelAgentTaskModelCatalog | Promise<PanelAgentTaskModelCatalog>;
   /** Shows a system notification; injected so tests avoid Electron Notification. */
   showNotification?(notification: { title: string; body: string }): boolean;
   /** Host-owned Cookie login operations. Cookie values never cross into the Panel guest. */
@@ -338,6 +345,7 @@ export class PanelAppBridge {
 
   constructor(private readonly options: PanelAppBridgeOptions) {
     this.processService = new PanelAppProcessService({
+      extraPathDirectories: () => [this.managedBinDirectory()],
       confirmExecution: async ({ guestId, appTitle, executable, executablePath }) => {
         const owner = this.guests.get(guestId);
         const window = owner ? BrowserWindow.fromId(owner.ownerWindowId) : null;
@@ -384,6 +392,7 @@ export class PanelAppBridge {
                 bucket: input.owner.bucket,
                 behaviorMode: "isolatedTask",
                 ephemeral: true,
+                ...(input.model ? { model: input.model } : {}),
                 toolAllowlist: input.toolNames,
                 skillAllowlist: input.skillNames,
                 maxTurns: input.maxTurns,
@@ -816,7 +825,9 @@ export class PanelAppBridge {
       this.assertProjectBinding(bound);
       return { ...bound.context };
     };
-    return binding.bucket ? readContext(binding) : this.waitForBoundGuest(binding).then(readContext);
+    return binding.bucket
+      ? readContext(binding)
+      : this.waitForBoundGuest(binding).then(readContext);
   }
 
   private async call(sender: WebContents, method: string, params?: unknown): Promise<unknown> {
@@ -907,6 +918,9 @@ export class PanelAppBridge {
           this.agentTaskOwner(binding),
           (params ?? {}) as PanelAgentTaskStartInput,
         );
+      case "agent.task.models":
+        this.requirePermission(binding, "agent.task");
+        return this.options.agentTaskModels?.(binding.cwd ?? binding.projectPath) ?? { models: [] };
       case "agent.task.list":
         this.requirePermission(binding, "agent.task");
         return this.agentTaskService.list(this.agentTaskOwner(binding));
@@ -976,6 +990,9 @@ export class PanelAppBridge {
       case "process.find":
         this.requirePermission(binding, "process");
         return this.processService.findExecutable(this.processOwner(binding), params);
+      case "process.info":
+        this.requirePermission(binding, "process");
+        return panelProcessInfo();
       case "process.spawn":
         this.requirePermission(binding, "process");
         return this.processService.start(this.processOwner(binding), params);
@@ -1031,8 +1048,26 @@ export class PanelAppBridge {
 
   private getKnownProcessDirectory(binding: GuestBinding, params: unknown): Promise<unknown> {
     const name = (params as { name?: unknown } | null)?.name;
-    if (name !== "downloads") throw new Error("unsupported known directory");
-    return this.processService.grantDirectory(this.processOwner(binding), app.getPath("downloads"));
+    if (name === "downloads") {
+      return this.processService.grantDirectory(
+        this.processOwner(binding),
+        app.getPath("downloads"),
+      );
+    }
+    if (name === "user-bin") {
+      return this.grantManagedBinDirectory(binding);
+    }
+    throw new Error("unsupported known directory");
+  }
+
+  private managedBinDirectory(): string {
+    return join(app.getPath("userData"), "bin");
+  }
+
+  private async grantManagedBinDirectory(binding: GuestBinding): Promise<unknown> {
+    const path = this.managedBinDirectory();
+    await mkdir(path, { recursive: true, mode: 0o700 });
+    return this.processService.grantDirectory(this.processOwner(binding), path);
   }
 
   private async pickProcessDirectory(binding: GuestBinding): Promise<unknown> {

--- a/packages/desktop/src/main/panel-app-process-service.test.ts
+++ b/packages/desktop/src/main/panel-app-process-service.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   PanelAppProcessService,
+  panelProcessInfo,
   resolvePanelExecutable,
   type PanelProcessOwner,
 } from "./panel-app-process-service.js";
@@ -33,6 +34,33 @@ describe("PanelAppProcessService", () => {
     await expect(resolvePanelExecutable("../demo-tool", { env: { PATH: root } })).rejects.toThrow(
       /invalid executable name/,
     );
+  });
+
+  test("resolves Host-managed executables outside the inherited PATH", async () => {
+    const path = executable("managed-tool", 'printf "ok\\n"');
+    expect(
+      await resolvePanelExecutable("managed-tool", {
+        env: { PATH: "" },
+        extraPathDirectories: [root],
+      }),
+    ).toBe(realpathSync(path));
+  });
+
+  test("reports Linux libc without exposing other process details", () => {
+    expect(panelProcessInfo("linux", "x64", { header: { glibcVersionRuntime: "2.39" } })).toEqual({
+      platform: "linux",
+      arch: "x64",
+      libc: "glibc",
+    });
+    expect(panelProcessInfo("linux", "arm64", { header: {} })).toEqual({
+      platform: "linux",
+      arch: "arm64",
+      libc: "musl",
+    });
+    expect(panelProcessInfo("darwin", "arm64", {})).toEqual({
+      platform: "darwin",
+      arch: "arm64",
+    });
   });
 
   test("runs argv without a shell and streams output to the owning guest", async () => {

--- a/packages/desktop/src/main/panel-app-process-service.ts
+++ b/packages/desktop/src/main/panel-app-process-service.ts
@@ -44,6 +44,8 @@ interface RunningProcess {
 export interface PanelAppProcessServiceOptions {
   env?: NodeJS.ProcessEnv;
   platform?: NodeJS.Platform;
+  /** Host-owned executable directories (for example CodeShell's managed bin). */
+  extraPathDirectories?: () => readonly string[];
   confirmExecution(input: {
     guestId: number;
     appId: string;
@@ -53,7 +55,27 @@ export interface PanelAppProcessServiceOptions {
   }): Promise<boolean>;
 }
 
-function safeProcessEnv(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+export function panelProcessInfo(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+  report: unknown = process.report?.getReport(),
+): { platform: NodeJS.Platform; arch: string; libc?: "glibc" | "musl" } {
+  if (platform !== "linux") return { platform, arch };
+  const header =
+    report && typeof report === "object"
+      ? (report as { header?: { glibcVersionRuntime?: unknown } }).header
+      : undefined;
+  const libc =
+    typeof header?.glibcVersionRuntime === "string" && header.glibcVersionRuntime
+      ? "glibc"
+      : "musl";
+  return { platform, arch, libc };
+}
+
+function safeProcessEnv(
+  source: NodeJS.ProcessEnv,
+  extraPathDirectories: readonly string[] = [],
+): NodeJS.ProcessEnv {
   const allowed = [
     "PATH",
     "HOME",
@@ -68,9 +90,14 @@ function safeProcessEnv(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
     "SSL_CERT_FILE",
     "SSL_CERT_DIR",
   ];
-  return Object.fromEntries(
+  const safe = Object.fromEntries(
     allowed.flatMap((key) => (source[key] === undefined ? [] : [[key, source[key]]])),
   );
+  const currentPath = safe.PATH ?? "";
+  safe.PATH = [...extraPathDirectories.filter(Boolean), currentPath]
+    .filter(Boolean)
+    .join(delimiter);
+  return safe;
 }
 
 function executableCandidates(name: string, platform: NodeJS.Platform, env: NodeJS.ProcessEnv) {
@@ -84,13 +111,21 @@ function executableCandidates(name: string, platform: NodeJS.Platform, env: Node
 
 export async function resolvePanelExecutable(
   name: string,
-  options: { env?: NodeJS.ProcessEnv; platform?: NodeJS.Platform } = {},
+  options: {
+    env?: NodeJS.ProcessEnv;
+    platform?: NodeJS.Platform;
+    extraPathDirectories?: readonly string[];
+  } = {},
 ): Promise<string | null> {
   if (!EXECUTABLE_NAME.test(name)) throw new Error("invalid executable name");
   const env = options.env ?? process.env;
   const platform = options.platform ?? process.platform;
   const pathValue = env.PATH || "";
-  for (const directory of pathValue.split(delimiter).filter(Boolean)) {
+  const directories = [
+    ...(options.extraPathDirectories ?? []),
+    ...pathValue.split(delimiter).filter(Boolean),
+  ];
+  for (const directory of [...new Set(directories)]) {
     for (const candidateName of executableCandidates(name, platform, env)) {
       const candidate = join(directory, candidateName);
       try {
@@ -137,7 +172,10 @@ export class PanelAppProcessService {
     if (typeof name !== "string" || !EXECUTABLE_NAME.test(name)) {
       throw new Error("process.find requires a simple executable name");
     }
-    const path = await resolvePanelExecutable(name, this.options);
+    const path = await resolvePanelExecutable(name, {
+      ...this.options,
+      extraPathDirectories: this.options.extraPathDirectories?.(),
+    });
     if (!path) return { available: false, name };
     const handle = randomUUID();
     this.executables.set(handle, { guestId: owner.guestId, name, path });
@@ -207,7 +245,10 @@ export class PanelAppProcessService {
     const child = spawn(executable.path, args, {
       cwd,
       detached: process.platform !== "win32",
-      env: safeProcessEnv(this.options.env ?? process.env),
+      env: safeProcessEnv(
+        this.options.env ?? process.env,
+        this.options.extraPathDirectories?.() ?? [],
+      ),
       shell: false,
       stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true,

--- a/packages/desktop/src/shared/panel-apps.ts
+++ b/packages/desktop/src/shared/panel-apps.ts
@@ -1,4 +1,4 @@
-export const PANEL_APP_API_VERSION = 8 as const;
+export const PANEL_APP_API_VERSION = 9 as const;
 
 export const PANEL_APP_PERMISSION_NAMES = [
   "context.session",

--- a/packages/server/src/sessions-service.home.test.ts
+++ b/packages/server/src/sessions-service.home.test.ts
@@ -28,6 +28,7 @@ describe("desktop session services CODE_SHELL_HOME routing", () => {
     const manager = new SessionManager();
     manager.create(cwd, "model", "provider", "normal-in-custom-home", null, "desktop");
     manager.create(cwd, "model", "provider", "qchat-in-custom-home", null, "desktop");
+    manager.create(cwd, "model", "provider", "panel-task-legacy", null, "desktop");
 
     expect(sessionsRoot()).toBe(join(codeShellHome, "sessions"));
     expect((await listDiskSessions({ limit: 10 })).sessions.map((session) => session.id)).toEqual([

--- a/packages/server/src/sessions-service.test.ts
+++ b/packages/server/src/sessions-service.test.ts
@@ -90,8 +90,9 @@ describe("deleteSessionDir", () => {
     expect(fs.existsSync(nonQuickStage)).toBe(true);
   });
 
-  it("does not expose legacy flat qchat records in the sessions view", async () => {
+  it("does not expose legacy flat ephemeral records in the sessions view", async () => {
     fs.writeFileSync(path.join(dir, "qchat-hidden.jsonl"), "quick transcript");
+    fs.writeFileSync(path.join(dir, "panel-task-hidden.jsonl"), "panel task transcript");
     fs.writeFileSync(path.join(dir, "normal-visible.jsonl"), "normal transcript");
 
     expect((await listSessions(dir)).map((session) => session.id)).toEqual(["normal-visible"]);

--- a/packages/server/src/sessions-service.ts
+++ b/packages/server/src/sessions-service.ts
@@ -19,9 +19,14 @@ export interface DesktopSessionSummary {
 
 const SAFE_ID = /^[A-Za-z0-9_.-]+$/;
 const QUICK_CHAT_SESSION_PREFIX = "qchat-";
+const PANEL_TASK_SESSION_PREFIX = "panel-task-";
 
 function isQuickChatSessionId(id: string): boolean {
   return id.startsWith(QUICK_CHAT_SESSION_PREFIX);
+}
+
+function isInternalEphemeralSessionId(id: string): boolean {
+  return isQuickChatSessionId(id) || id.startsWith(PANEL_TASK_SESSION_PREFIX);
 }
 
 export async function listSessions(
@@ -34,7 +39,7 @@ export async function listSessions(
       if (!e.isFile()) continue;
       if (!e.name.endsWith(".jsonl") && !e.name.endsWith(".json")) continue;
       const id = e.name.replace(/\.jsonl?$/, "");
-      if (isQuickChatSessionId(id)) continue;
+      if (isInternalEphemeralSessionId(id)) continue;
       const full = path.join(baseDir, e.name);
       try {
         const st = await fs.stat(full);
@@ -208,7 +213,7 @@ export async function listDiskSessions(
     throw e;
   }
   const candidates = entries.filter(
-    (e) => e.isDirectory() && SAFE_ID.test(e.name) && !isQuickChatSessionId(e.name),
+    (e) => e.isDirectory() && SAFE_ID.test(e.name) && !isInternalEphemeralSessionId(e.name),
   );
   const stats = await Promise.all(
     candidates.map(async (e) => {


### PR DESCRIPTION
## Summary
- expose secret-free configured text models to isolated Panel Tasks
- add Panel API v9 process metadata and a Host-managed executable directory
- keep Panel Task sessions ephemeral and hide legacy panel-task records

## Validation
- 19 targeted tests passed
- Desktop typecheck passed
- changed-file lint passed