### PR TITLE
fix(panel-apps): improve setup discovery on Windows

### DIFF
--- a/packages/core/src/panel-apps/installer.test.ts
+++ b/packages/core/src/panel-apps/installer.test.ts
@@ -354,6 +354,10 @@ describe("independent Panel App installer", () => {
     const previousFetch = globalThis.fetch;
     try {
       writePanelApp(appRoot, { id: "remote-panel", version: "1.0.0" });
+      writePanelApp(join(repository, "examples", "other-panel"), {
+        id: "other-panel",
+        version: "1.0.0",
+      });
       runGit(repository, "init", "--initial-branch=main");
       runGit(repository, "config", "user.email", "panel-tests@codeshell.local");
       runGit(repository, "config", "user.name", "Panel Tests");
@@ -378,6 +382,16 @@ describe("independent Panel App installer", () => {
           },
         });
       });
+
+      const monorepoError = await previewLocalPanelApp({
+        kind: "git",
+        url: cloneUrl,
+        ref: "main",
+      }).catch((error) => error);
+      expect(String(monorepoError)).toMatch(
+        /multiple Panel Apps found.*examples\/other-panel.*examples\/panel-app/,
+      );
+      expect(String(monorepoError)).not.toContain("panel-source-main/");
 
       const source = {
         kind: "git" as const,

--- a/packages/core/src/panel-apps/installer.ts
+++ b/packages/core/src/panel-apps/installer.ts
@@ -45,6 +45,9 @@ const MAX_FILE_BYTES = 16 * 1024 * 1024;
 const MAX_DEPTH = 16;
 const MAX_MANIFEST_BYTES = 1024 * 1024;
 const MAX_AGENT_SKILL_BYTES = 256 * 1024;
+const MAX_PANEL_DISCOVERY_DEPTH = 4;
+const MAX_PANEL_DISCOVERY_DIRECTORIES = 512;
+const MAX_PANEL_DISCOVERY_RESULTS = 16;
 const REVIEWED_GIT_SNAPSHOT_TTL_MS = 10 * 60 * 1000;
 const MAX_REVIEWED_GIT_SNAPSHOTS = 8;
 const ALLOWED_ASSET_EXTENSIONS = new Set([
@@ -248,15 +251,50 @@ function looksLikePanelAppRoot(directory: string): boolean {
   return existsSync(join(directory, PANEL_APP_MANIFEST_FILE));
 }
 
+async function discoverPanelAppRoots(directory: string): Promise<string[]> {
+  const found: string[] = [];
+  const pending = [{ directory, depth: 0 }];
+  let visited = 0;
+  while (
+    pending.length > 0 &&
+    visited < MAX_PANEL_DISCOVERY_DIRECTORIES &&
+    found.length < MAX_PANEL_DISCOVERY_RESULTS
+  ) {
+    const current = pending.shift()!;
+    visited += 1;
+    if (looksLikePanelAppRoot(current.directory)) {
+      found.push(current.directory);
+      continue;
+    }
+    if (current.depth >= MAX_PANEL_DISCOVERY_DEPTH) continue;
+    const entries = await readdir(current.directory, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name.startsWith(".") || entry.name === "node_modules") {
+        continue;
+      }
+      pending.push({ directory: join(current.directory, entry.name), depth: current.depth + 1 });
+    }
+  }
+  return found;
+}
+
 async function findPanelAppRoot(directory: string): Promise<string> {
   if (looksLikePanelAppRoot(directory)) return directory;
-  const entries = await readdir(directory, { withFileTypes: true });
-  const children = entries.filter((entry) => entry.isDirectory() && !entry.name.startsWith("."));
-  if (children.length === 1) {
-    const nested = join(directory, children[0].name);
-    if (looksLikePanelAppRoot(nested)) return nested;
+  const found = await discoverPanelAppRoots(directory);
+  if (found.length === 1) return found[0];
+  if (found.length > 1) {
+    const candidates = found
+      .map((root) => relative(directory, root).split(sep).join(posix.sep))
+      .sort()
+      .join(", ");
+    throw new PanelAppInstallError(
+      `multiple Panel Apps found; choose an app subdirectory: ${candidates}`,
+    );
   }
-  throw new PanelAppInstallError(`no Panel App found (expected ${PANEL_APP_MANIFEST_FILE})`);
+  throw new PanelAppInstallError(
+    `no Panel App found (expected ${PANEL_APP_MANIFEST_FILE}); ` +
+      "for a monorepo, provide the app subdirectory or a GitHub /tree/<ref>/<path> URL",
+  );
 }
 
 async function openGitPanelAppSource(

--- a/packages/desktop/src/main/panel-app-bridge.ts
+++ b/packages/desktop/src/main/panel-app-bridge.ts
@@ -24,6 +24,7 @@ import type { PanelAppProtocolResource } from "./panel-app-protocol.js";
 import { preparePanelApp } from "./panel-app-protocol.js";
 import {
   PanelAppProcessService,
+  panelExecutableDirectories,
   panelProcessInfo,
   type PanelProcessOwner,
 } from "./panel-app-process-service.js";
@@ -345,7 +346,8 @@ export class PanelAppBridge {
 
   constructor(private readonly options: PanelAppBridgeOptions) {
     this.processService = new PanelAppProcessService({
-      extraPathDirectories: () => [this.managedBinDirectory()],
+      extraPathDirectories: () =>
+        panelExecutableDirectories(this.managedBinDirectory(), { home: app.getPath("home") }),
       confirmExecution: async ({ guestId, appTitle, executable, executablePath }) => {
         const owner = this.guests.get(guestId);
         const window = owner ? BrowserWindow.fromId(owner.ownerWindowId) : null;

--- a/packages/desktop/src/main/panel-app-process-service.test.ts
+++ b/packages/desktop/src/main/panel-app-process-service.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   PanelAppProcessService,
+  panelExecutableDirectories,
   panelProcessInfo,
   resolvePanelExecutable,
   type PanelProcessOwner,
@@ -61,6 +62,19 @@ describe("PanelAppProcessService", () => {
       platform: "darwin",
       arch: "arm64",
     });
+  });
+
+  test("adds Windows package-manager links without relying on the startup PATH", () => {
+    expect(
+      panelExecutableDirectories("C:\\CodeShell\\bin", {
+        platform: "win32",
+        env: { LOCALAPPDATA: "C:\\Users\\Mimi\\AppData\\Local" },
+      }),
+    ).toEqual([
+      "C:\\CodeShell\\bin",
+      "C:\\Users\\Mimi\\AppData\\Local/Microsoft/WinGet/Links",
+      "C:\\Users\\Mimi\\AppData\\Local/Microsoft/WindowsApps",
+    ]);
   });
 
   test("runs argv without a shell and streams output to the owning guest", async () => {

--- a/packages/desktop/src/main/panel-app-process-service.ts
+++ b/packages/desktop/src/main/panel-app-process-service.ts
@@ -72,6 +72,30 @@ export function panelProcessInfo(
   return { platform, arch, libc };
 }
 
+export function panelExecutableDirectories(
+  managedBin: string,
+  options: {
+    platform?: NodeJS.Platform;
+    env?: NodeJS.ProcessEnv;
+    home?: string;
+  } = {},
+): string[] {
+  const platform = options.platform ?? process.platform;
+  const env = options.env ?? process.env;
+  const directories = [managedBin];
+  if (platform === "win32") {
+    const localAppData =
+      env.LOCALAPPDATA || (options.home ? join(options.home, "AppData", "Local") : "");
+    if (localAppData) {
+      directories.push(
+        join(localAppData, "Microsoft", "WinGet", "Links"),
+        join(localAppData, "Microsoft", "WindowsApps"),
+      );
+    }
+  }
+  return [...new Set(directories.filter(Boolean))];
+}
+
 function safeProcessEnv(
   source: NodeJS.ProcessEnv,
   extraPathDirectories: readonly string[] = [],


### PR DESCRIPTION
## Summary
- discover nested Panel Apps and report valid monorepo subdirectories instead of a generic missing-manifest error
- scan CodeShell managed binaries plus WinGet Links and WindowsApps without relying on the startup PATH snapshot
- add installer and Windows executable-directory coverage

## Verification
- bun test --timeout 30000 packages/core/src/panel-apps/installer.test.ts packages/desktop/src/main/panel-app-process-service.test.ts
- bun run typecheck:workspaces