### PR TITLE
feat(desktop): authorize saved cookies for panel processes

### DIFF
--- a/docs/panel-apps.md
+++ b/docs/panel-apps.md
@@ -183,6 +183,16 @@ directory automatically included in Panel process lookup and child `PATH`, so
 reviewed apps can install a verified standalone tool without guessing a system
 directory or changing the user's shell profile.
 
+Panel API v10 adds `credentials.cookies.authorizeProcess` for apps that declare
+both `credentials.cookies` and `process`. After explicit user confirmation, the
+Host materializes a selected saved login into an owner-only temporary Netscape
+Cookie file and returns only an opaque, executable-bound file-argument handle.
+Passing that handle in `process.spawn.fileArgumentHandles` inserts the fixed
+`--cookies` option and private file path inside Desktop main; neither the Cookie values
+nor the path cross into the Panel guest. Grants are scoped to one guest and one
+resolved executable, and their temporary files are removed when the Panel
+closes.
+
 ```js
 const task = await window.codeshellPanel.call("agent.task.start", {
   key: "repair",

--- a/packages/desktop/scripts/e2e-panel-app.mjs
+++ b/packages/desktop/scripts/e2e-panel-app.mjs
@@ -337,7 +337,7 @@ try {
   assert(context.cwd === projectDir, "workspace permission was not scoped correctly");
   assert(context.trusted === false, "workspace trust must be decided by main");
   assert(context.theme === "dark" && context.locale === "en", "host context was not bound");
-  assert(context.apiVersion === 9, "Panel App bridge API v9 was not exposed");
+  assert(context.apiVersion === 10, "Panel App bridge API v10 was not exposed");
   const agentToolResult = await win.evaluate(
     ({ appDescriptorId }) =>
       window.codeshell.invokePanelAppAgentTool({

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -35,6 +35,7 @@ import {
   writeSettingsSchemaFile,
   userHome,
   CredentialStore,
+  materializeCookieSecret,
   type Credential,
   type CredentialScope,
   validateLocalLinkToken,
@@ -250,6 +251,7 @@ import {
   captureAllCookies,
   captureAllCookiesFromSessions,
   restoreCookiesToBrowser,
+  cleanupLease,
   sweepStaleLeases,
   BROWSER_PARTITION,
   type ElectronCookieLike,
@@ -700,6 +702,23 @@ const panelAppBridge = new PanelAppBridge({
         if (!window.isDestroyed()) window.webContents.send("browser:reload", { bucket });
       }
       return { count: result.count };
+    },
+    materialize: async ({ credentialId, cwd }) => {
+      await migrateCredentialStore(cwd);
+      const credential = new CredentialStore(cwd).resolve(credentialId);
+      if (!credential || credential.type !== "cookie") {
+        throw new Error(`No saved Cookie login: ${credentialId}`);
+      }
+      try {
+        const materialized = materializeCookieSecret(credential.id, credential.secret ?? "");
+        return {
+          filePath: materialized.cookiesFile,
+          count: materialized.count,
+          cleanup: () => cleanupLease(materialized.cookiesFile),
+        };
+      } catch {
+        return { invalid: true as const };
+      }
     },
   },
   automations: {

--- a/packages/desktop/src/main/panel-app-bridge.ts
+++ b/packages/desktop/src/main/panel-app-bridge.ts
@@ -159,6 +159,10 @@ export interface PanelAppBridgeOptions {
       cwd?: string;
       bucket?: string;
     }): Promise<{ count: number } | { invalid: true }>;
+    materialize?(input: {
+      credentialId: string;
+      cwd?: string;
+    }): Promise<{ filePath: string; count: number; cleanup: () => void } | { invalid: true }>;
   };
   /** Project- and task-scoped recurring jobs. The Panel never receives jobs from another cwd. */
   automations?: {
@@ -866,7 +870,9 @@ export class PanelAppBridge {
             ? AUDIO_TRANSCRIBE_TIMEOUT_MS
             : method === "credentials.cookies.loginAndSave"
               ? COOKIE_LOGIN_TIMEOUT_MS
-              : method === "filesystem.pickDirectory" || method === "process.spawn"
+              : method === "filesystem.pickDirectory" ||
+                  method === "process.spawn" ||
+                  method === "credentials.cookies.authorizeProcess"
                 ? PROCESS_CONSENT_TIMEOUT_MS
                 : CALL_TIMEOUT_MS),
     );
@@ -980,6 +986,10 @@ export class PanelAppBridge {
       case "credentials.cookies.restore":
         this.requirePermission(binding, "credentials.cookies");
         return this.restoreCookieCredential(binding, params);
+      case "credentials.cookies.authorizeProcess":
+        this.requirePermission(binding, "credentials.cookies");
+        this.requirePermission(binding, "process");
+        return this.authorizeCookieCredentialForProcess(binding, params);
       case "automations.list":
         this.requirePermission(binding, "automations.manage");
         return this.listPanelAutomations(binding);
@@ -1438,6 +1448,67 @@ export class PanelAppBridge {
     });
     if ("invalid" in result) return { restored: false, invalid: true };
     return { restored: true, count: result.count };
+  }
+
+  private async authorizeCookieCredentialForProcess(
+    binding: GuestBinding,
+    params: unknown,
+  ): Promise<unknown> {
+    const input = params as {
+      credentialId?: unknown;
+      url?: unknown;
+      executableHandle?: unknown;
+    } | null;
+    const credentialId = typeof input?.credentialId === "string" ? input.credentialId.trim() : "";
+    if (!credentialId || credentialId.length > 160) {
+      throw new Error("Cookie process authorization requires a saved credential id");
+    }
+    const url = this.cookieCredentialUrl(params);
+    const host = this.cookieCredentialHost(binding);
+    if (!host.materialize) {
+      throw new Error("Cookie process authorization is unavailable in this CodeShell host");
+    }
+    const account = (await host.list(binding.cwd)).find(
+      (credential) =>
+        credential.id === credentialId && this.cookieCredentialDomainMatches(url, credential),
+    );
+    if (!account) throw new Error("The selected Cookie login does not match this site");
+    if (account.health === "corrupted") {
+      throw new Error("The selected Cookie login is corrupted; sign in and save it again");
+    }
+    const owner = this.processOwner(binding);
+    const executable = this.processService.executableName(owner, input?.executableHandle);
+    const window = BrowserWindow.fromId(binding.ownerWindowId);
+    if (!window || window.isDestroyed()) throw new Error("owner window is unavailable");
+    const decision = await dialog.showMessageBox(window, {
+      type: "question",
+      buttons: ["Use saved login", "Cancel"],
+      defaultId: 1,
+      cancelId: 1,
+      title: binding.resource.descriptor.title,
+      message: `Use “${account.label}” with ${executable}?`,
+      detail:
+        "CodeShell will create a temporary owner-only Cookie file and pass it directly to the selected local program. The Panel App receives only an opaque handle, never the Cookie contents or file path. The file is removed when the Panel closes.",
+      noLink: true,
+    });
+    if (decision.response !== 0) return { authorized: false, cancelled: true };
+
+    const materialized = await host.materialize({ credentialId, cwd: binding.cwd });
+    if ("invalid" in materialized) {
+      return { authorized: false, invalid: true };
+    }
+    try {
+      const grant = await this.processService.grantFileArgument(owner, {
+        executableHandle: input?.executableHandle,
+        argumentName: "--cookies",
+        path: materialized.filePath,
+        cleanup: materialized.cleanup,
+      });
+      return { authorized: true, fileArgumentHandle: grant.handle, count: materialized.count };
+    } catch (error) {
+      materialized.cleanup();
+      throw error;
+    }
   }
 
   private storagePath(binding: GuestBinding): string {

--- a/packages/desktop/src/main/panel-app-process-service.test.ts
+++ b/packages/desktop/src/main/panel-app-process-service.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { chmodSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -144,5 +144,79 @@ describe("PanelAppProcessService", () => {
         args: [],
       }),
     ).rejects.toThrow(/belongs to another Panel App/);
+  });
+
+  test("passes sealed files only to their bound executable and cleans them on revoke", async () => {
+    executable(
+      "cookie-tool",
+      'printf "flag:%s\\n" "$1"; { IFS= read -r first; IFS= read -r second; printf "cookie:%s\\n" "$second"; } < "$2"; printf "tail:%s\\n" "$3"',
+    );
+    executable("other-tool", 'printf "should-not-run\\n"');
+    const secretFile = join(root, "cookies.txt");
+    writeFileSync(
+      secretFile,
+      "# Netscape HTTP Cookie File\n.example.com\\tTRUE\\t/\\tTRUE\\t0\\tsid\\tcookie-secret\n",
+      {
+        mode: 0o600,
+      },
+    );
+    const events: Array<{ event: string; payload: Record<string, unknown> }> = [];
+    let resolveExit = (): void => undefined;
+    const exited = new Promise<void>((resolve) => {
+      resolveExit = resolve;
+    });
+    const owner: PanelProcessOwner = {
+      guestId: 9,
+      appId: "cookie-demo",
+      appTitle: "Cookie Demo",
+      revision: "r1",
+      send: (event, payload) => {
+        events.push({ event, payload });
+        if (event === "process.exit") resolveExit();
+      },
+    };
+    const service = new PanelAppProcessService({
+      env: { PATH: root },
+      confirmExecution: async () => true,
+    });
+    const executableGrant = await service.findExecutable(owner, { name: "cookie-tool" });
+    const otherExecutable = await service.findExecutable(owner, { name: "other-tool" });
+    const directory = await service.grantDirectory(owner, root);
+    const sealed = await service.grantFileArgument(owner, {
+      executableHandle: executableGrant.handle,
+      argumentName: "--cookies",
+      path: secretFile,
+      cleanup: () => rmSync(secretFile, { force: true }),
+    });
+    expect(sealed).toEqual({ handle: expect.any(String) });
+    expect(JSON.stringify(sealed)).not.toContain(secretFile);
+
+    await expect(
+      service.start(owner, {
+        executableHandle: otherExecutable.handle,
+        directoryHandle: directory.handle,
+        fileArgumentHandles: [sealed.handle],
+        args: [],
+      }),
+    ).rejects.toThrow(/bound to a different executable/);
+
+    await service.start(owner, {
+      executableHandle: executableGrant.handle,
+      directoryHandle: directory.handle,
+      fileArgumentHandles: [sealed.handle],
+      args: ["last"],
+    });
+    await exited;
+    const output = events
+      .filter((entry) => entry.event === "process.output")
+      .map((entry) => entry.payload.text)
+      .join("");
+    expect(output).toContain("flag:--cookies");
+    expect(output).toContain("cookie:.example.com");
+    expect(output).toContain("tail:last");
+    expect(existsSync(secretFile)).toBe(true);
+
+    service.revokeGuest(owner.guestId);
+    expect(existsSync(secretFile)).toBe(false);
   });
 });

--- a/packages/desktop/src/main/panel-app-process-service.ts
+++ b/packages/desktop/src/main/panel-app-process-service.ts
@@ -6,10 +6,12 @@ import { basename, delimiter, extname, join } from "node:path";
 import { killProcessGroup } from "@cjhyy/code-shell-core/extension";
 
 const EXECUTABLE_NAME = /^[a-zA-Z0-9][a-zA-Z0-9._+-]{0,127}$/;
+const FILE_ARGUMENT_NAME = /^--[a-zA-Z][a-zA-Z0-9-]{0,63}$/;
 const MAX_ARGUMENTS = 256;
 const MAX_ARGUMENT_LENGTH = 8_192;
 const MAX_ARGUMENT_BYTES = 64 * 1024;
 const MAX_CONCURRENT_PROCESSES = 3;
+const MAX_FILE_ARGUMENTS = 8;
 const MAX_EVENT_CHARS = 16_384;
 const MAX_PROCESS_OUTPUT_BYTES = 4 * 1024 * 1024;
 const PROCESS_LIFETIME_MS = 24 * 60 * 60 * 1_000;
@@ -31,6 +33,14 @@ interface ExecutableGrant {
 interface DirectoryGrant {
   guestId: number;
   path: string;
+}
+
+interface FileArgumentGrant {
+  guestId: number;
+  executablePath: string;
+  argumentName: string;
+  path: string;
+  cleanup: () => void;
 }
 
 interface RunningProcess {
@@ -180,9 +190,27 @@ function validateArguments(raw: unknown): string[] {
   return args;
 }
 
+function validateFileArgumentHandles(raw: unknown): string[] {
+  if (raw === undefined) return [];
+  if (!Array.isArray(raw) || raw.length > MAX_FILE_ARGUMENTS) {
+    throw new Error(`process.spawn accepts at most ${MAX_FILE_ARGUMENTS} sealed file arguments`);
+  }
+  const handles = raw.map((value) => {
+    if (typeof value !== "string" || !value || value.length > 160) {
+      throw new Error("process.spawn sealed file argument handles must be bounded strings");
+    }
+    return value;
+  });
+  if (new Set(handles).size !== handles.length) {
+    throw new Error("process.spawn sealed file argument handles must be unique");
+  }
+  return handles;
+}
+
 export class PanelAppProcessService {
   private readonly executables = new Map<string, ExecutableGrant>();
   private readonly directories = new Map<string, DirectoryGrant>();
+  private readonly fileArguments = new Map<string, FileArgumentGrant>();
   private readonly processes = new Map<string, RunningProcess>();
   private readonly approvedExecutables = new Set<string>();
 
@@ -218,6 +246,48 @@ export class PanelAppProcessService {
     return { handle, path: resolved, name: basename(resolved) || resolved };
   }
 
+  executableName(owner: PanelProcessOwner, handle: unknown): string {
+    if (typeof handle !== "string") throw new Error("executable handle is required");
+    const executable = this.executables.get(handle);
+    if (!executable || executable.guestId !== owner.guestId) {
+      throw new Error("executable handle is invalid or belongs to another Panel App");
+    }
+    return executable.name;
+  }
+
+  async grantFileArgument(
+    owner: PanelProcessOwner,
+    input: {
+      executableHandle: unknown;
+      argumentName: unknown;
+      path: string;
+      cleanup?: () => void;
+    },
+  ): Promise<{ handle: string }> {
+    if (typeof input.executableHandle !== "string") {
+      throw new Error("sealed file arguments require an executable handle");
+    }
+    const executable = this.executables.get(input.executableHandle);
+    if (!executable || executable.guestId !== owner.guestId) {
+      throw new Error("executable handle is invalid or belongs to another Panel App");
+    }
+    if (typeof input.argumentName !== "string" || !FILE_ARGUMENT_NAME.test(input.argumentName)) {
+      throw new Error("sealed file arguments require a simple long-option name");
+    }
+    const resolved = await realpath(input.path);
+    const info = await stat(resolved);
+    if (!info.isFile()) throw new Error("sealed process input is not a file");
+    const handle = randomUUID();
+    this.fileArguments.set(handle, {
+      guestId: owner.guestId,
+      executablePath: executable.path,
+      argumentName: input.argumentName,
+      path: resolved,
+      cleanup: input.cleanup ?? (() => undefined),
+    });
+    return { handle };
+  }
+
   directoryPath(owner: PanelProcessOwner, handle: unknown): string {
     if (typeof handle !== "string") throw new Error("directory handle is required");
     const grant = this.directories.get(handle);
@@ -235,6 +305,7 @@ export class PanelAppProcessService {
       executableHandle?: unknown;
       directoryHandle?: unknown;
       args?: unknown;
+      fileArgumentHandles?: unknown;
     } | null;
     if (!input || typeof input.executableHandle !== "string") {
       throw new Error("process.spawn requires an executable handle from process.find");
@@ -244,7 +315,20 @@ export class PanelAppProcessService {
       throw new Error("executable handle is invalid or belongs to another Panel App");
     }
     const cwd = this.directoryPath(owner, input.directoryHandle);
-    const args = validateArguments(input.args);
+    const rawArgs = validateArguments(input.args);
+    const fileArgumentHandles = validateFileArgumentHandles(input.fileArgumentHandles);
+    const sealedArgs: string[] = [];
+    for (const handle of fileArgumentHandles) {
+      const grant = this.fileArguments.get(handle);
+      if (!grant || grant.guestId !== owner.guestId) {
+        throw new Error("sealed file argument handle is invalid or belongs to another Panel App");
+      }
+      if (grant.executablePath !== executable.path) {
+        throw new Error("sealed file argument is bound to a different executable");
+      }
+      sealedArgs.push(grant.argumentName, grant.path);
+    }
+    const args = validateArguments([...sealedArgs, ...rawArgs]);
     const active = [...this.processes.values()].filter(
       (process) => process.guestId === owner.guestId,
     ).length;
@@ -352,6 +436,15 @@ export class PanelAppProcessService {
       clearTimeout(running.lifetime);
       this.terminate(running);
       this.processes.delete(processId);
+    }
+    for (const [handle, grant] of this.fileArguments) {
+      if (grant.guestId !== guestId) continue;
+      this.fileArguments.delete(handle);
+      try {
+        grant.cleanup();
+      } catch {
+        // Credential-backed temporary inputs are best-effort cleanup only.
+      }
     }
   }
 

--- a/packages/desktop/src/shared/panel-apps.ts
+++ b/packages/desktop/src/shared/panel-apps.ts
@@ -1,4 +1,4 @@
-export const PANEL_APP_API_VERSION = 9 as const;
+export const PANEL_APP_API_VERSION = 10 as const;
 
 export const PANEL_APP_PERMISSION_NAMES = [
   "context.session",

--- a/packages/desktop/tests/panel-app-main.test.ts
+++ b/packages/desktop/tests/panel-app-main.test.ts
@@ -13,6 +13,7 @@
 import { afterAll, afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
 import {
   chmodSync,
+  existsSync,
   mkdtempSync,
   mkdirSync,
   readFileSync,
@@ -22,7 +23,7 @@ import {
   symlinkSync,
   writeFileSync,
 } from "node:fs";
-import { basename, join } from "node:path";
+import { basename, delimiter, dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { PANEL_APP_API_VERSION } from "../src/shared/panel-apps.js";
 import { installPanelAppElectronMock, panelAppElectronMock } from "./panel-app-electron-mock.js";
@@ -929,6 +930,77 @@ describeIsolated("PanelAppBridge", () => {
       }),
     ).toEqual({ restored: false, invalid: true });
     expect(restoreRequests).toHaveLength(2);
+  });
+
+  test("authorizes a Cookie as an opaque executable-bound process argument", async () => {
+    const executableRoot = mkdtempSync(join(tmpdir(), "panel-cookie-process-"));
+    const previousPath = process.env.PATH;
+    const cookieFile = join(executableRoot, "cookies.txt");
+    try {
+      const executableName = basename(process.execPath);
+      process.env.PATH = `${dirname(process.execPath)}${delimiter}${previousPath ?? ""}`;
+      writeFileSync(
+        cookieFile,
+        "# Netscape HTTP Cookie File\n.example.com\tTRUE\t/\tTRUE\t0\tsid\tsecret\n",
+        {
+          mode: 0o600,
+        },
+      );
+      const bridge = new PanelAppBridge({
+        isTrustedHost: () => true,
+        isWorkspaceTrusted: () => true,
+        isPanelAppBound: () => true,
+        getAgentBridge: () => null,
+        cookieCredentials: {
+          list: async () => [
+            { id: "video-account", label: "Video account", domain: "example.com" },
+          ],
+          loginAndSave: async () => ({ ok: false as const, error: "unused" }),
+          restore: async () => ({ count: 0 }),
+          materialize: async () => ({
+            filePath: cookieFile,
+            count: 1,
+            cleanup: () => rmSync(cookieFile, { force: true }),
+          }),
+        },
+      });
+      bridge.registerIpc();
+      const guest = fakeGuest(28);
+      bridge.registerGuest(
+        guest as any,
+        panelAppElectronMock.ownerWindow as any,
+        bridgeResource(["credentials.cookies", "process"]) as any,
+        "/repo",
+      );
+      await bindBridgeGuest(28);
+      const call = (method: string, params: unknown) =>
+        panelAppElectronMock.ipcHandlers.get("panel-app:call")!(
+          { sender: guest },
+          method,
+          params,
+        ) as Promise<any>;
+      const executable = await call("process.find", { name: executableName });
+      panelAppElectronMock.dialogResponse = 0;
+      const authorization = await call("credentials.cookies.authorizeProcess", {
+        credentialId: "video-account",
+        url: "https://media.example.com/watch/1",
+        executableHandle: executable.handle,
+      });
+
+      expect(authorization).toEqual({
+        authorized: true,
+        fileArgumentHandle: expect.any(String),
+        count: 1,
+      });
+      expect(JSON.stringify(authorization)).not.toContain(cookieFile);
+      expect(JSON.stringify(authorization)).not.toContain("secret");
+      expect(existsSync(cookieFile)).toBe(true);
+      bridge.revokeGuest(28);
+      expect(existsSync(cookieFile)).toBe(false);
+    } finally {
+      process.env.PATH = previousPath;
+      rmSync(executableRoot, { recursive: true, force: true });
+    }
   });
 
   test("never resolves a Cookie account from a shorter or bare-suffix host", async () => {


### PR DESCRIPTION
## Summary\n- add Panel API v10 Cookie-to-process authorization\n- keep Cookie contents and temporary file paths inside Desktop main\n- bind opaque file arguments to one panel guest and exact executable\n- remove temporary Cookie files when the panel closes\n\n## Validation\n- bun test packages/desktop/src/main/panel-app-process-service.test.ts\n- bun test ./packages/desktop/src/main/panel-app-protocol.test.ts\n- bun run --cwd packages/desktop typecheck\n- targeted ESLint and Prettier