### PR TITLE
feat(panel-apps): add recommended catalog and simpler repo discovery

### DIFF
--- a/packages/core/src/engine/engine.ts
+++ b/packages/core/src/engine/engine.ts
@@ -130,8 +130,6 @@ import {
 import { EngineRuntime } from "./runtime.js";
 import { buildRunUserMessageContent, prepareRunImageInput } from "./run-image-input.js";
 import {
-  ISOLATED_TASK_PROFILE,
-  QUICK_CHAT_RESTRICTED_PROFILE,
   type EngineRunOptions,
   type RunBehaviorProfile,
 } from "./run-types.js";

--- a/packages/core/src/panel-apps/installer.test.ts
+++ b/packages/core/src/panel-apps/installer.test.ts
@@ -409,6 +409,16 @@ describe("independent Panel App installer", () => {
       ]);
       expect(discovery.issues).toEqual([]);
 
+      const shorthandDiscovery = await discoverGitPanelApps({
+        kind: "git",
+        url: "codeshell-tests/panel-source",
+      });
+      expect(shorthandDiscovery.source.url).toBe(cloneUrl);
+      expect(shorthandDiscovery.panels.map((panel) => panel.id)).toEqual([
+        "other-panel",
+        "remote-panel",
+      ]);
+
       const scopedDiscovery = await discoverGitPanelApps({
         kind: "git",
         url: cloneUrl,

--- a/packages/core/src/panel-apps/installer.ts
+++ b/packages/core/src/panel-apps/installer.ts
@@ -192,9 +192,14 @@ function normalizeGitPanelAppSource(input: GitPanelAppSourceInput): GitPanelAppS
   if (!raw || raw.length > MAX_SOURCE_PATH || raw.includes("\0")) {
     throw new PanelAppInstallError("GitHub repository URL is invalid");
   }
+  const urlText = /^[A-Za-z0-9_.-]{1,100}\/[A-Za-z0-9_.-]{1,100}(?:\.git)?\/?$/.test(raw)
+    ? `https://github.com/${raw}`
+    : /^github\.com\//i.test(raw)
+      ? `https://${raw}`
+      : raw;
   let parsed: URL;
   try {
-    parsed = new URL(raw);
+    parsed = new URL(urlText);
   } catch {
     throw new PanelAppInstallError("GitHub repository URL is invalid");
   }

--- a/packages/desktop/src/renderer/extensions/PanelsTab.test.ts
+++ b/packages/desktop/src/renderer/extensions/PanelsTab.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { nextPanelAppBindings } from "./PanelsTab";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { DialogProvider } from "../ui/DialogProvider";
+import { ToastProvider } from "../ui/ToastProvider";
+import { nextPanelAppBindings, PanelsTab } from "./PanelsTab";
+import {
+  OFFICIAL_PANEL_APP_REPOSITORY,
+  recommendedPanelApps,
+  recommendedPanelSource,
+} from "./panelAppRecommendations";
 
 describe("Panel App controls", () => {
   const appId = "design-studio";
@@ -8,5 +17,47 @@ describe("Panel App controls", () => {
     expect(nextPanelAppBindings(["quant-lab"], appId, true)).toEqual([appId, "quant-lab"]);
     expect(nextPanelAppBindings(["quant-lab", appId], appId, false)).toEqual(["quant-lab"]);
     expect(nextPanelAppBindings([42, appId, null], appId, false)).toEqual([]);
+  });
+
+  test("ships distinct official recommendations that point to exact apps", () => {
+    expect(recommendedPanelApps.map((app) => app.id)).toEqual([
+      "video-download",
+      "design-studio",
+      "job-hunt-hq",
+      "quant-lab",
+    ]);
+    expect(new Set(recommendedPanelApps.map((app) => app.subdir)).size).toBe(
+      recommendedPanelApps.length,
+    );
+    expect(recommendedPanelSource(recommendedPanelApps[0])).toEqual({
+      kind: "git",
+      url: OFFICIAL_PANEL_APP_REPOSITORY,
+      ref: "main",
+      subdir: "apps/video-download",
+    });
+  });
+
+  test("renders the official recommendations before any remote request", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(
+        ToastProvider,
+        null,
+        React.createElement(
+          DialogProvider,
+          null,
+          React.createElement(PanelsTab, {
+            cwd: "/tmp/project",
+            activeProjectPath: "/tmp/project",
+            query: "",
+          }),
+        ),
+      ),
+    );
+    expect(html).toContain("推荐面板");
+    expect(html).toContain("Mimi Download");
+    expect(html).toContain("设计工作台");
+    expect(html).toContain("求职作战室");
+    expect(html).toContain("量化实验室");
+    expect(html).toContain("查看仓库全部面板");
   });
 });

--- a/packages/desktop/src/renderer/extensions/PanelsTab.tsx
+++ b/packages/desktop/src/renderer/extensions/PanelsTab.tsx
@@ -1,15 +1,20 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   AlertTriangle,
+  Briefcase,
   ChevronDown,
   ChevronRight,
   Code2,
+  Download,
   FileArchive,
   FolderPlus,
   Github,
+  LineChart,
   Loader2,
+  Palette,
   PanelTop,
   RefreshCw,
+  SlidersHorizontal,
   Trash2,
 } from "lucide-react";
 import type {
@@ -35,6 +40,12 @@ import {
   withoutLegacyOverride,
   type ProjectSettingsMap,
 } from "./panelAppBindings";
+import {
+  OFFICIAL_PANEL_APP_REPOSITORY,
+  recommendedPanelApps,
+  recommendedPanelSource,
+  type RecommendedPanelApp,
+} from "./panelAppRecommendations";
 
 interface Props {
   cwd: string;
@@ -57,6 +68,14 @@ export function nextPanelAppBindings(value: unknown, appId: string, bound: boole
   return [...bindings].sort();
 }
 
+function RecommendedPanelIcon({ icon }: { icon: RecommendedPanelApp["icon"] }) {
+  const className = "h-4 w-4";
+  if (icon === "download") return <Download className={className} aria-hidden="true" />;
+  if (icon === "palette") return <Palette className={className} aria-hidden="true" />;
+  if (icon === "briefcase") return <Briefcase className={className} aria-hidden="true" />;
+  return <LineChart className={className} aria-hidden="true" />;
+}
+
 /** Desktop Panel Apps with optional sandboxed Agent tools and bundled Skills. */
 export function PanelsTab({ cwd, activeProjectPath, query }: Props) {
   const { t, lang } = useT();
@@ -69,6 +88,8 @@ export function PanelsTab({ cwd, activeProjectPath, query }: Props) {
   const [gitUrl, setGitUrl] = useState("");
   const [gitRef, setGitRef] = useState("");
   const [gitSubdir, setGitSubdir] = useState("");
+  const [gitAdvancedOpen, setGitAdvancedOpen] = useState(false);
+  const [gitBusyTarget, setGitBusyTarget] = useState<string | null>(null);
   const [gitDiscovery, setGitDiscovery] = useState<GitPanelAppDiscovery | null>(null);
   const [review, setReview] = useState<PanelAppReviewState | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
@@ -224,6 +245,11 @@ export function PanelsTab({ cwd, activeProjectPath, query }: Props) {
   };
 
   const reviewGitCandidate = async (source: GitPanelAppSourceInput) => {
+    if (!activeProjectPath) {
+      setError(t("ext.panels.projectRequired"));
+      return;
+    }
+    setGitBusyTarget(source.subdir ?? source.url);
     setInstallBusy("git");
     setError(null);
     try {
@@ -236,25 +262,17 @@ export function PanelsTab({ cwd, activeProjectPath, query }: Props) {
     } catch (cause) {
       setError(String((cause as Error)?.message ?? cause));
     } finally {
+      setGitBusyTarget(null);
       setInstallBusy(null);
     }
   };
 
-  const discoverGit = async () => {
+  const discoverGitSource = async (source: GitPanelAppSourceInput) => {
     if (!activeProjectPath) {
       setError(t("ext.panels.projectRequired"));
       return;
     }
-    if (!gitUrl.trim()) {
-      setError(t("ext.panels.githubUrlRequired"));
-      return;
-    }
-    const source: GitPanelAppSourceInput = {
-      kind: "git",
-      url: gitUrl.trim(),
-      ...(gitRef.trim() ? { ref: gitRef.trim() } : {}),
-      ...(gitSubdir.trim() ? { subdir: gitSubdir.trim() } : {}),
-    };
+    setGitBusyTarget("discovery");
     setInstallBusy("git");
     setError(null);
     setGitDiscovery(null);
@@ -265,20 +283,34 @@ export function PanelsTab({ cwd, activeProjectPath, query }: Props) {
         return;
       }
       setGitDiscovery(result.discovery);
-      if (result.discovery.panels.length === 1) {
-        const candidate = result.discovery.panels[0];
-        const preview = await window.codeshell.previewLocalPanelApp(candidate.source);
-        if (!preview.ok) {
-          setError(preview.error);
-          return;
-        }
-        setReview({ mode: "install", source: candidate.source, preview: preview.preview });
-      }
     } catch (cause) {
       setError(String((cause as Error)?.message ?? cause));
     } finally {
+      setGitBusyTarget(null);
       setInstallBusy(null);
     }
+  };
+
+  const discoverGit = async () => {
+    if (!gitUrl.trim()) {
+      setError(t("ext.panels.githubUrlRequired"));
+      return;
+    }
+    await discoverGitSource({
+      kind: "git",
+      url: gitUrl.trim(),
+      ...(gitRef.trim() ? { ref: gitRef.trim() } : {}),
+      ...(gitSubdir.trim() ? { subdir: gitSubdir.trim() } : {}),
+    });
+  };
+
+  const browseOfficialPanels = async () => {
+    setGitOpen(true);
+    setGitAdvancedOpen(false);
+    setGitUrl(OFFICIAL_PANEL_APP_REPOSITORY);
+    setGitRef("");
+    setGitSubdir("");
+    await discoverGitSource({ kind: "git", url: OFFICIAL_PANEL_APP_REPOSITORY });
   };
 
   const installReviewed = async () => {
@@ -428,6 +460,7 @@ export function PanelsTab({ cwd, activeProjectPath, query }: Props) {
         ...(app.agent?.tools.map((tool) => tool.name) ?? []),
       ].some((value) => value.toLowerCase().includes(needle)),
   );
+  const installedAppIds = useMemo(() => new Set((apps ?? []).map((app) => app.appId)), [apps]);
 
   const bindingsByApp = useMemo(() => {
     const map = new Map<string, ReturnType<typeof computeProjectBindings>>();
@@ -519,56 +552,117 @@ export function PanelsTab({ cwd, activeProjectPath, query }: Props) {
             {t("ext.panels.fromGithub")}
           </Button>
         </div>
+
+        <div className="mt-4 border-t pt-3">
+          <div className="flex flex-wrap items-start justify-between gap-2">
+            <div>
+              <div className="flex items-center gap-2 text-xs font-semibold text-foreground">
+                {t("ext.panels.recommendedTitle")}
+                <Badge variant="secondary" className="text-[10px]">
+                  {t("ext.panels.recommendedOfficial")}
+                </Badge>
+              </div>
+              <div className="mt-0.5 text-xs leading-5 text-muted-foreground">
+                {t("ext.panels.recommendedDesc")}
+              </div>
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              className="h-7 gap-1.5 px-2 text-xs"
+              disabled={installBusy !== null || !activeProjectPath}
+              onClick={() => void browseOfficialPanels()}
+            >
+              {gitBusyTarget === "discovery" ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Github className="h-3.5 w-3.5" />
+              )}
+              {t("ext.panels.recommendedBrowseAll")}
+            </Button>
+          </div>
+          <div className="mt-2 grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+            {recommendedPanelApps.map((recommendation) => {
+              const installed = installedAppIds.has(recommendation.id);
+              const reviewing = gitBusyTarget === recommendation.subdir;
+              return (
+                <button
+                  key={recommendation.id}
+                  type="button"
+                  className="group flex min-h-[112px] min-w-0 flex-col rounded-lg border bg-background p-3 text-left transition-colors hover:border-primary/50 hover:bg-primary/5 disabled:cursor-not-allowed disabled:opacity-60"
+                  disabled={installBusy !== null || !activeProjectPath || installed}
+                  onClick={() => void reviewGitCandidate(recommendedPanelSource(recommendation))}
+                >
+                  <span className="flex w-full items-start gap-2.5">
+                    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+                      <RecommendedPanelIcon icon={recommendation.icon} />
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm font-medium text-foreground">
+                        {t(`ext.panels.recommendedApps.${recommendation.i18nKey}.title`)}
+                      </span>
+                      <span className="mt-0.5 line-clamp-2 block text-xs leading-5 text-muted-foreground">
+                        {t(`ext.panels.recommendedApps.${recommendation.i18nKey}.description`)}
+                      </span>
+                    </span>
+                  </span>
+                  <span className="mt-auto flex w-full items-center justify-between pt-2 text-xs font-medium text-primary">
+                    <span>
+                      {installed
+                        ? t("ext.panels.recommendedInstalled")
+                        : reviewing
+                          ? t("ext.panels.recommendedLoading")
+                          : t("ext.panels.recommendedReview")}
+                    </span>
+                    {reviewing ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : installed ? (
+                      <Badge variant="success" className="text-[10px]">
+                        {t("ext.panels.recommendedInstalled")}
+                      </Badge>
+                    ) : (
+                      <ChevronRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" />
+                    )}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
         {gitOpen && (
-          <div className="mt-3 grid gap-2 rounded-lg border bg-muted/15 p-3 sm:grid-cols-[2fr_1fr_2fr_auto]">
-            <label className="space-y-1">
-              <span className="text-xs font-medium text-foreground">
-                {t("ext.panels.githubUrl")}
-              </span>
-              <Input
-                value={gitUrl}
-                placeholder="https://github.com/owner/repository"
-                onChange={(event) => {
-                  setGitUrl(event.target.value);
-                  setGitDiscovery(null);
-                }}
-              />
-            </label>
-            <label className="space-y-1">
-              <span className="text-xs font-medium text-foreground">
-                {t("ext.panels.githubRef")}
-              </span>
-              <Input
-                value={gitRef}
-                placeholder="main"
-                onChange={(event) => {
-                  setGitRef(event.target.value);
-                  setGitDiscovery(null);
-                }}
-              />
-            </label>
-            <label className="space-y-1">
-              <span className="text-xs font-medium text-foreground">
-                {t("ext.panels.githubSubdir")}
-              </span>
-              <Input
-                value={gitSubdir}
-                placeholder="apps/design-studio"
-                onChange={(event) => {
-                  setGitSubdir(event.target.value);
-                  setGitDiscovery(null);
-                }}
-              />
-            </label>
-            <div className="flex items-end">
+          <form
+            className="mt-3 space-y-2 rounded-lg border bg-muted/15 p-3"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void discoverGit();
+            }}
+          >
+            <div className="grid items-end gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
+              <label className="space-y-1">
+                <span className="text-xs font-medium text-foreground">
+                  {t("ext.panels.githubUrl")}
+                </span>
+                <Input
+                  value={gitUrl}
+                  placeholder={t("ext.panels.githubUrlPlaceholder")}
+                  autoCapitalize="none"
+                  autoCorrect="off"
+                  spellCheck={false}
+                  onChange={(event) => {
+                    setGitUrl(event.target.value);
+                    setGitDiscovery(null);
+                  }}
+                />
+              </label>
               <Button
-                type="button"
+                type="submit"
                 size="sm"
                 className="w-full gap-1.5 sm:w-auto"
                 disabled={installBusy !== null}
-                onClick={() => void discoverGit()}
               >
-                {installBusy === "git" ? (
+                {gitBusyTarget === "discovery" ? (
                   <Loader2 className="h-3.5 w-3.5 animate-spin" />
                 ) : (
                   <Github className="h-3.5 w-3.5" />
@@ -576,11 +670,56 @@ export function PanelsTab({ cwd, activeProjectPath, query }: Props) {
                 {t("ext.panels.discoverGithub")}
               </Button>
             </div>
-            <div className="text-xs text-muted-foreground sm:col-span-4">
+            <div className="text-xs leading-5 text-muted-foreground">
               {t("ext.panels.githubHint")}
             </div>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              className="h-7 gap-1.5 px-2 text-xs text-muted-foreground"
+              onClick={() => setGitAdvancedOpen((open) => !open)}
+            >
+              <SlidersHorizontal className="h-3.5 w-3.5" aria-hidden="true" />
+              {t("ext.panels.githubAdvanced")}
+              {gitAdvancedOpen ? (
+                <ChevronDown className="h-3.5 w-3.5" />
+              ) : (
+                <ChevronRight className="h-3.5 w-3.5" />
+              )}
+            </Button>
+            {gitAdvancedOpen && (
+              <div className="grid gap-2 rounded-md border bg-background/60 p-2 sm:grid-cols-2">
+                <label className="space-y-1">
+                  <span className="text-xs font-medium text-foreground">
+                    {t("ext.panels.githubRef")}
+                  </span>
+                  <Input
+                    value={gitRef}
+                    placeholder="main"
+                    onChange={(event) => {
+                      setGitRef(event.target.value);
+                      setGitDiscovery(null);
+                    }}
+                  />
+                </label>
+                <label className="space-y-1">
+                  <span className="text-xs font-medium text-foreground">
+                    {t("ext.panels.githubSubdir")}
+                  </span>
+                  <Input
+                    value={gitSubdir}
+                    placeholder="apps/design-studio"
+                    onChange={(event) => {
+                      setGitSubdir(event.target.value);
+                      setGitDiscovery(null);
+                    }}
+                  />
+                </label>
+              </div>
+            )}
             {gitDiscovery && (
-              <div className="space-y-2 border-t pt-3 sm:col-span-4">
+              <div className="space-y-2 border-t pt-3">
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <div className="text-xs font-medium text-foreground">
                     {t("ext.panels.githubDiscovered", {
@@ -609,7 +748,11 @@ export function PanelsTab({ cwd, activeProjectPath, query }: Props) {
                         onClick={() => void reviewGitCandidate(candidate.source)}
                       >
                         <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
-                          <PanelTop className="h-4 w-4" aria-hidden="true" />
+                          {gitBusyTarget === candidate.subdir ? (
+                            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                          ) : (
+                            <PanelTop className="h-4 w-4" aria-hidden="true" />
+                          )}
                         </span>
                         <span className="min-w-0 flex-1">
                           <span className="flex items-center gap-2">
@@ -635,7 +778,7 @@ export function PanelsTab({ cwd, activeProjectPath, query }: Props) {
                 </div>
               </div>
             )}
-          </div>
+          </form>
         )}
         <div className="mt-3 grid gap-2 border-t pt-3 text-xs text-muted-foreground sm:grid-cols-3">
           {[

--- a/packages/desktop/src/renderer/extensions/panelAppRecommendations.ts
+++ b/packages/desktop/src/renderer/extensions/panelAppRecommendations.ts
@@ -1,0 +1,43 @@
+import type { GitPanelAppSourceInput } from "../../preload/types";
+
+export const OFFICIAL_PANEL_APP_REPOSITORY = "https://github.com/cjhyy/codeshell-panel-apps.git";
+
+export const recommendedPanelApps = [
+  {
+    id: "video-download",
+    subdir: "apps/video-download",
+    i18nKey: "videoDownload",
+    icon: "download",
+  },
+  {
+    id: "design-studio",
+    subdir: "apps/design-studio",
+    i18nKey: "designStudio",
+    icon: "palette",
+  },
+  {
+    id: "job-hunt-hq",
+    subdir: "apps/job-hunt-hq",
+    i18nKey: "jobHunt",
+    icon: "briefcase",
+  },
+  {
+    id: "quant-lab",
+    subdir: "apps/quant-lab",
+    i18nKey: "quantLab",
+    icon: "chart",
+  },
+] as const;
+
+export type RecommendedPanelApp = (typeof recommendedPanelApps)[number];
+
+export function recommendedPanelSource(
+  recommendation: Pick<RecommendedPanelApp, "subdir">,
+): GitPanelAppSourceInput {
+  return {
+    kind: "git",
+    url: OFFICIAL_PANEL_APP_REPOSITORY,
+    ref: "main",
+    subdir: recommendation.subdir,
+  };
+}

--- a/packages/desktop/src/renderer/i18n/ns/extensions.ts
+++ b/packages/desktop/src/renderer/i18n/ns/extensions.ts
@@ -48,15 +48,43 @@ export const extensions = {
         fromDir: "选择源码文件夹",
         fromZip: "从压缩包",
         fromGithub: "从 GitHub",
+        recommendedTitle: "推荐面板",
+        recommendedOfficial: "官方精选",
+        recommendedDesc:
+          "来自 CodeShell 官方面板仓库；点击后会读取最新版本和权限，再由你确认安装。",
+        recommendedBrowseAll: "查看仓库全部面板",
+        recommendedInstalled: "已安装",
+        recommendedLoading: "正在读取…",
+        recommendedReview: "查看并安装",
+        recommendedApps: {
+          videoDownload: {
+            title: "Mimi Download",
+            description: "粘贴链接下载视频，可选 Cookie、画质与字幕，失败时再让 AI 分析。",
+          },
+          designStudio: {
+            title: "设计工作台",
+            description: "在项目中制作界面、原型，并把设计直接交付为前端实现。",
+          },
+          jobHunt: {
+            title: "求职作战室",
+            description: "长期保存职位、简历、题库、练习与面试复盘。",
+          },
+          quantLab: {
+            title: "量化实验室",
+            description: "使用项目内的本地数据研究股票策略并进行回测。",
+          },
+        },
         githubUrl: "GitHub 仓库",
+        githubUrlPlaceholder: "owner/repository 或完整 GitHub 地址",
         githubRef: "分支或标签（可选）",
         githubSubdir: "面板子目录（可选）",
+        githubAdvanced: "高级定位（分支、子目录）",
         reviewGithub: "拉取并审查",
         discoverGithub: "查找面板",
         githubDiscovered: "发现 {count} 个 Panel App，选择一个继续审查",
         githubInvalid: "另有 {count} 个目录未通过校验",
         githubHint:
-          "只填写公开 GitHub 仓库地址即可自动查找其中的 Panel App；子目录仅用于缩小查找范围。",
+          "粘贴公开 GitHub 仓库地址即可扫描仓库中的全部 Panel App；无需先填写分支或子目录。",
         githubUrlRequired: "请输入 GitHub 仓库地址。",
         addStepManifest: "创建 .codeshell-panel/panel.json",
         addStepApp: "把 HTML、JS、CSS 放进 app/ 目录",
@@ -928,15 +956,46 @@ export const extensions = {
         fromDir: "Choose source folder",
         fromZip: "From archive",
         fromGithub: "From GitHub",
+        recommendedTitle: "Recommended panels",
+        recommendedOfficial: "Official picks",
+        recommendedDesc:
+          "From the official CodeShell panel repository. CodeShell fetches the latest version and permissions for your review before installation.",
+        recommendedBrowseAll: "Browse all repository panels",
+        recommendedInstalled: "Installed",
+        recommendedLoading: "Fetching…",
+        recommendedReview: "Review and install",
+        recommendedApps: {
+          videoDownload: {
+            title: "Mimi Download",
+            description:
+              "Paste a video link, then choose Cookies, quality, and subtitles. Ask AI only when a download fails.",
+          },
+          designStudio: {
+            title: "Design Studio",
+            description:
+              "Create product UI and prototypes in a project, then hand them off as frontend implementation.",
+          },
+          jobHunt: {
+            title: "Job Hunt HQ",
+            description:
+              "Keep jobs, resumes, question banks, practice, and interview debriefs together over time.",
+          },
+          quantLab: {
+            title: "Quant Lab",
+            description: "Research and backtest stock strategies against local project data.",
+          },
+        },
         githubUrl: "GitHub repository",
+        githubUrlPlaceholder: "owner/repository or a full GitHub URL",
         githubRef: "Branch or tag (optional)",
         githubSubdir: "App subdirectory (optional)",
+        githubAdvanced: "Advanced location (branch and subdirectory)",
         reviewGithub: "Fetch and review",
         discoverGithub: "Find panels",
         githubDiscovered: "Found {count} Panel App(s). Choose one to continue reviewing.",
         githubInvalid: "{count} other folder(s) failed validation",
         githubHint:
-          "Enter only a public GitHub repository URL to find its Panel Apps automatically. The subdirectory only narrows the search.",
+          "Paste a public GitHub repository to scan every Panel App in it. You do not need to enter a branch or subdirectory first.",
         githubUrlRequired: "Enter a GitHub repository URL.",
         addStepManifest: "Create .codeshell-panel/panel.json",
         addStepApp: "Put HTML, JS, and CSS under app/",


### PR DESCRIPTION
## Summary
- show four official recommended Panel Apps before any network request
- scan an entire GitHub repository from one primary input and always show the discovered choices
- keep branch and subdirectory under advanced options
- accept owner/repository shorthand and verify multi-panel discovery

## Verification
- bun test packages/core/src/panel-apps/installer.test.ts packages/desktop/src/renderer/extensions/PanelsTab.test.ts packages/desktop/src/renderer/i18n/dict.test.ts packages/desktop/src/renderer/i18n/translate.test.ts
- bun run --cwd packages/desktop typecheck
- bun run --cwd packages/desktop build:renderer
- eslint on changed files
- live discovery against cjhyy/codeshell-panel-apps returned five valid manifests