### PR TITLE
chore: release 0.8.17

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
     },
     "packages/arena": {
       "name": "@cjhyy/code-shell-arena",
-      "version": "0.8.16",
+      "version": "0.8.17",
       "dependencies": {
         "@cjhyy/code-shell-core": "workspace:*",
         "zod": "^3.24.2",
@@ -35,11 +35,11 @@
     },
     "packages/cdp": {
       "name": "@cjhyy/code-shell-cdp",
-      "version": "0.8.16",
+      "version": "0.8.17",
     },
     "packages/chat": {
       "name": "@cjhyy/code-shell-chat",
-      "version": "0.8.16",
+      "version": "0.8.17",
       "bin": {
         "code-shell-chat": "./dist/cli.js",
       },
@@ -62,14 +62,14 @@
     },
     "packages/coding": {
       "name": "@cjhyy/code-shell-capability-coding",
-      "version": "0.8.16",
+      "version": "0.8.17",
       "dependencies": {
         "@cjhyy/code-shell-core": "workspace:*",
       },
     },
     "packages/core": {
       "name": "@cjhyy/code-shell-core",
-      "version": "0.8.16",
+      "version": "0.8.17",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
         "@modelcontextprotocol/sdk": "^1.12.1",
@@ -92,7 +92,7 @@
     },
     "packages/desktop": {
       "name": "@cjhyy/code-shell-desktop",
-      "version": "0.8.16",
+      "version": "0.8.17",
       "dependencies": {
         "@cjhyy/code-shell-arena": "workspace:*",
         "@cjhyy/code-shell-capability-coding": "workspace:*",
@@ -157,18 +157,18 @@
     },
     "packages/link": {
       "name": "@cjhyy/code-shell-link",
-      "version": "0.8.16",
+      "version": "0.8.17",
     },
     "packages/pet": {
       "name": "@cjhyy/code-shell-pet",
-      "version": "0.8.16",
+      "version": "0.8.17",
       "dependencies": {
         "@cjhyy/code-shell-core": "workspace:*",
       },
     },
     "packages/server": {
       "name": "@cjhyy/code-shell-server",
-      "version": "0.8.16",
+      "version": "0.8.17",
       "bin": {
         "code-shell-serve": "./dist/bin/code-shell-serve.js",
       },
@@ -182,7 +182,7 @@
     },
     "packages/tui": {
       "name": "@cjhyy/code-shell-tui",
-      "version": "0.8.16",
+      "version": "0.8.17",
       "bin": {
         "code-shell": "./dist/cli/main.js",
       },
@@ -219,7 +219,7 @@
     },
     "packages/web": {
       "name": "@cjhyy/code-shell-web",
-      "version": "0.8.16",
+      "version": "0.8.17",
       "dependencies": {
         "@cjhyy/code-shell-core": "workspace:*",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cjhyy/code-shell",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "description": "Code Shell — meta package. Installs @cjhyy/code-shell-core and @cjhyy/code-shell-tui.",
   "type": "module",
   "packageManager": "bun@1.3.11",

--- a/packages/arena/package.json
+++ b/packages/arena/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cjhyy/code-shell-arena",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "description": "Optional multi-model Arena capability for CodeShell.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cdp/package.json
+++ b/packages/cdp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cjhyy/code-shell-cdp",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "private": true,
   "description": "Environment-agnostic CDP browser action layer — drive a browser target (click/type/select/press_key/hover/scroll + raw observe) through an injected CDP sender. No Playwright, no launcher, no agent loop. Zero runtime dependencies.",
   "type": "module",

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cjhyy/code-shell-chat",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "description": "A standalone, transport-agnostic multi-channel chat gateway for Node.js and Bun.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/coding/package.json
+++ b/packages/coding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cjhyy/code-shell-capability-coding",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "description": "Coding capability pack for the generic code-shell agent core.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cjhyy/code-shell-core",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "description": "Core engine for code-shell — agent orchestration, tool execution, hooks, protocol. UI-agnostic.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,7 +4,7 @@
  * Public API exports.
  */
 
-export const VERSION = "0.8.16";
+export const VERSION = "0.8.17";
 
 // ─── Types ───────────────────────────────────────────────────────
 

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cjhyy/code-shell-desktop",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "private": true,
   "license": "MIT",
   "description": "Electron desktop client for CodeShell — the full desktop agent app.",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cjhyy/code-shell-link",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "description": "Framework-independent provider manifests and authorization guides for CodeShell Link.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/pet/package.json
+++ b/packages/pet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cjhyy/code-shell-pet",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "description": "Pet (top-level personal assistant) capability for CodeShell — projection state machine, DelegateWork contract, Mimi behavior profile.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cjhyy/code-shell-server",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "description": "CodeShell server transport layer — mobile remote HTTP/WS host, pairing, passcode gate, tunnel, rooms, uploads, and session/attachment services. Electron-free; precursor of the auth gateway.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cjhyy/code-shell-tui",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "description": "Terminal UI for code-shell — Ink-based REPL on top of @cjhyy/code-shell-core.",
   "license": "MIT",
   "repository": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cjhyy/code-shell-web",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "description": "CodeShell web client logic layer — remote-app state (chatReducer + server-event fold), reconnecting WebSocket hook, pairing/device-credential/risk helpers, and the mobile i18n namespace. Browser-only (no Electron, no Node); seed of the standalone browser client.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release
- bumps all CodeShell workspace packages and core VERSION to 0.8.17
- includes the merged Panel App recommendation catalog and simplified multi-panel GitHub discovery from #10

## Verification
- bun run scripts/verify-release-versions.ts 0.8.17